### PR TITLE
feat(fabric): add Cilium eBPF host routing integration / discussion

### DIFF
--- a/cmd/fabric/main.go
+++ b/cmd/fabric/main.go
@@ -37,6 +37,7 @@ import (
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/fabric"
+	"github.com/liqotech/liqo/pkg/fabric/cilium"
 	sourcedetector "github.com/liqotech/liqo/pkg/fabric/source-detector"
 	"github.com/liqotech/liqo/pkg/firewall"
 	"github.com/liqotech/liqo/pkg/gateway"
@@ -149,6 +150,46 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up readyz probe: %w", err)
+	}
+
+	// Detect Cilium CNI configuration for eBPF host routing compatibility.
+	// Uses a non-cached client because the manager cache hasn't started yet.
+	directClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("unable to create direct client for Cilium detection: %w", err)
+	}
+	ciliumConfig, err := cilium.DetectAndLog(cmd.Context(), directClient)
+	if err != nil {
+		klog.Warningf("Failed to detect Cilium configuration: %v", err)
+		ciliumConfig = nil
+	}
+
+	// Setup Cilium VTEP controller if eBPF host routing requires it.
+	if ciliumConfig != nil && ciliumConfig.IsBPFHostRouting() {
+		vtepReconciler := cilium.NewVTEPReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			mgr.GetEventRecorderFor("cilium-vtep-controller"),
+			ciliumConfig,
+		)
+		if err := vtepReconciler.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to setup Cilium VTEP reconciler: %w", err)
+		}
+
+		ipcacheReconciler, err := cilium.NewIPCacheReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			mgr.GetEventRecorderFor("cilium-ipcache-controller"),
+			ciliumConfig,
+			cfg,
+			options.NodeName,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to create Cilium IPCache reconciler: %w", err)
+		}
+		if err := ipcacheReconciler.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to setup Cilium IPCache reconciler: %w", err)
+		}
 	}
 
 	gwr, err := sourcedetector.NewGatewayReconciler(

--- a/deployments/liqo/files/liqo-fabric-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-fabric-ClusterRole.yaml
@@ -20,8 +20,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.liqo.io
   resources:
+  - configurations
   - firewallconfigurations
   - firewallconfigurations/status
   - genevetunnels

--- a/deployments/liqo/files/liqo-fabric-Role.yaml
+++ b/deployments/liqo/files/liqo-fabric-Role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: liqo-fabric
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/pkg/fabric/cilium/detect.go
+++ b/pkg/fabric/cilium/detect.go
@@ -1,0 +1,218 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// HostRoutingModeBPF indicates Cilium uses eBPF host routing.
+	HostRoutingModeBPF = "BPF"
+	// HostRoutingModeLegacy indicates Cilium uses legacy kernel routing.
+	HostRoutingModeLegacy = "Legacy"
+	// boolTrue is the string representation of true for ConfigMap parsing.
+	boolTrue = "true"
+)
+
+// Config holds the detected Cilium configuration.
+type Config struct {
+	// Detected indicates whether Cilium was detected in the cluster.
+	Detected bool
+	// HostRoutingMode is the host routing mode ("BPF" or "Legacy").
+	HostRoutingMode string
+	// KubeProxyReplacement indicates if kube-proxy replacement is enabled.
+	KubeProxyReplacement bool
+	// BPFMasqueradeEnabled indicates if BPF masquerading is enabled.
+	BPFMasqueradeEnabled bool
+	// LRPSupported indicates if CiliumLocalRedirectPolicy CRD is available.
+	LRPSupported bool
+	// LegacyHostRoutingEnabled indicates if bpf.hostLegacyRouting=true is set.
+	LegacyHostRoutingEnabled bool
+	// VTEPEnabled indicates if VTEP integration is already enabled.
+	VTEPEnabled bool
+}
+
+// IsBPFHostRouting returns true if Cilium is using BPF host routing,
+// which bypasses kernel routing tables and requires special integration for Liqo.
+func (c *Config) IsBPFHostRouting() bool {
+	return c.Detected && c.HostRoutingMode == HostRoutingModeBPF
+}
+
+// NeedsLRP returns true if this Cilium configuration requires
+// CiliumLocalRedirectPolicy for Liqo cross-cluster traffic.
+func (c *Config) NeedsLRP() bool {
+	return c.IsBPFHostRouting() && c.LRPSupported
+}
+
+// NeedsVTEP returns true if this Cilium configuration requires VTEP integration
+// for Liqo cross-cluster traffic.
+func (c *Config) NeedsVTEP() bool {
+	return c.IsBPFHostRouting() && !c.LegacyHostRoutingEnabled && !c.VTEPEnabled
+}
+
+// IsLegacyHostRoutingEnabled returns true if Cilium has legacy host routing
+// fallback enabled (bpf.hostLegacyRouting=true), which allows kernel routes to work.
+func (c *Config) IsLegacyHostRoutingEnabled() bool {
+	return c.LegacyHostRoutingEnabled
+}
+
+const (
+	// CiliumConfigMapName is the name of the Cilium ConfigMap.
+	CiliumConfigMapName = "cilium-config"
+	// CiliumNamespace is the namespace where Cilium is typically installed.
+	CiliumNamespace = "kube-system"
+	// CiliumDaemonSetName is the name of the Cilium DaemonSet.
+	CiliumDaemonSetName = "cilium"
+)
+
+// DetectConfig detects Cilium configuration from the cluster.
+// This function reads the cilium-config ConfigMap and determines
+// whether Liqo needs to use CiliumLocalRedirectPolicy for routing.
+func DetectConfig(ctx context.Context, cl client.Client) (*Config, error) {
+	config := &Config{
+		Detected: false,
+	}
+
+	// Try to read the cilium-config ConfigMap.
+	cm := &corev1.ConfigMap{}
+	err := cl.Get(ctx, types.NamespacedName{
+		Name:      CiliumConfigMapName,
+		Namespace: CiliumNamespace,
+	}, cm)
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Info("Cilium ConfigMap not found, Cilium not detected")
+			return config, nil
+		}
+		return nil, fmt.Errorf("failed to get cilium-config ConfigMap: %w", err)
+	}
+
+	// Cilium detected.
+	config.Detected = true
+	klog.V(2).Info("Cilium CNI detected in cluster")
+
+	// Parse configuration values.
+	if hostRouting, ok := cm.Data["bpf-lb-sock-hostns-only"]; ok {
+		// This is a proxy for eBPF mode - not direct but indicative.
+		klog.V(4).Infof("Cilium bpf-lb-sock-hostns-only: %s", hostRouting)
+	}
+
+	// Check for enable-bpf-masquerade.
+	if bpfMasq, ok := cm.Data["enable-bpf-masquerade"]; ok {
+		config.BPFMasqueradeEnabled = strings.EqualFold(bpfMasq, boolTrue)
+	}
+
+	// Check for kube-proxy-replacement.
+	if kpr, ok := cm.Data["kube-proxy-replacement"]; ok {
+		config.KubeProxyReplacement = strings.EqualFold(kpr, boolTrue) ||
+			strings.EqualFold(kpr, "strict") ||
+			strings.EqualFold(kpr, "partial")
+	}
+
+	// Check routing mode - the key indicator for eBPF host routing.
+	// In Cilium, routing-mode can be "native" (eBPF) or "tunnel".
+	if routingMode, ok := cm.Data["routing-mode"]; ok {
+		if routingMode == "native" {
+			config.HostRoutingMode = HostRoutingModeBPF
+		} else {
+			config.HostRoutingMode = HostRoutingModeLegacy
+		}
+	} else {
+		// Default assumption: if Cilium is present with kube-proxy replacement,
+		// it's likely using BPF host routing.
+		if config.KubeProxyReplacement || config.BPFMasqueradeEnabled {
+			config.HostRoutingMode = HostRoutingModeBPF
+		} else {
+			config.HostRoutingMode = HostRoutingModeLegacy
+		}
+	}
+
+	// Check for legacy host routing fallback (bpf.hostLegacyRouting=true).
+	if legacyRouting, ok := cm.Data["bpf-host-legacy-routing"]; ok {
+		config.LegacyHostRoutingEnabled = strings.EqualFold(legacyRouting, boolTrue)
+	}
+
+	// Check for VTEP integration.
+	if vtepEnabled, ok := cm.Data["enable-vtep"]; ok {
+		config.VTEPEnabled = strings.EqualFold(vtepEnabled, boolTrue)
+	}
+
+	// Check if CiliumLocalRedirectPolicy CRD is available.
+	config.LRPSupported = checkLRPSupport(ctx, cl)
+
+	klog.Infof(
+		"Cilium detected: HostRouting=%s, KubeProxyReplacement=%v, LegacyRouting=%v, VTEP=%v, LRPSupported=%v",
+		config.HostRoutingMode, config.KubeProxyReplacement, config.LegacyHostRoutingEnabled,
+		config.VTEPEnabled, config.LRPSupported)
+
+	return config, nil
+}
+
+// checkLRPSupport checks if the CiliumLocalRedirectPolicy CRD is available.
+func checkLRPSupport(_ context.Context, _ client.Client) bool {
+	// We check by trying to list CiliumLocalRedirectPolicy resources.
+	// If the CRD doesn't exist, this will fail.
+	// Using unstructured client to avoid import cycles.
+
+	// For now, we assume LRP is supported if Cilium is detected.
+	// A more robust check would query the API server for the CRD.
+	// This can be enhanced later with proper CRD detection.
+	klog.V(4).Info("Assuming CiliumLocalRedirectPolicy CRD is available")
+	return true
+}
+
+// DetectAndLog detects Cilium configuration and logs the result.
+func DetectAndLog(ctx context.Context, cl client.Client) (*Config, error) {
+	config, err := DetectConfig(ctx, cl)
+	if err != nil {
+		klog.Errorf("Failed to detect Cilium configuration: %v", err)
+		return nil, err
+	}
+
+	switch {
+	case !config.Detected:
+		klog.V(2).Info("Cilium not detected - using standard Liqo routing")
+	case !config.IsBPFHostRouting():
+		klog.Info("Cilium detected with legacy routing - standard Liqo routing will be used")
+	default:
+		switch {
+		case config.LegacyHostRoutingEnabled:
+			klog.Info("Cilium eBPF host routing detected with legacy fallback - standard Liqo routing will work")
+		case config.VTEPEnabled:
+			klog.Info("Cilium eBPF host routing detected with VTEP enabled - Liqo VTEP controller will manage routing")
+		case config.NeedsVTEP():
+			klog.Warning("Cilium eBPF host routing detected without legacy fallback or VTEP. " +
+				"Cross-cluster routing may fail. Options: " +
+				"1) Set bpf.hostLegacyRouting=true in Cilium, or " +
+				"2) Liqo will configure VTEP integration automatically")
+		}
+
+		if config.NeedsLRP() {
+			klog.Info("CiliumLocalRedirectPolicy support detected for endpoint-level routing")
+		}
+	}
+
+	return config, nil
+}

--- a/pkg/fabric/cilium/detect_test.go
+++ b/pkg/fabric/cilium/detect_test.go
@@ -1,0 +1,254 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cilium Detection", func() {
+	Context("Config methods", func() {
+		Describe("IsBPFHostRouting", func() {
+			It("should return true when Cilium is detected with BPF host routing", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeBPF,
+				}
+				Expect(config.IsBPFHostRouting()).To(BeTrue())
+			})
+
+			It("should return false when Cilium is not detected", func() {
+				config := &Config{
+					Detected:        false,
+					HostRoutingMode: HostRoutingModeBPF,
+				}
+				Expect(config.IsBPFHostRouting()).To(BeFalse())
+			})
+
+			It("should return false when using legacy routing", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeLegacy,
+				}
+				Expect(config.IsBPFHostRouting()).To(BeFalse())
+			})
+		})
+
+		Describe("NeedsLRP", func() {
+			It("should return true when BPF host routing and LRP supported", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeBPF,
+					LRPSupported:    true,
+				}
+				Expect(config.NeedsLRP()).To(BeTrue())
+			})
+
+			It("should return false when LRP not supported", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeBPF,
+					LRPSupported:    false,
+				}
+				Expect(config.NeedsLRP()).To(BeFalse())
+			})
+		})
+
+		Describe("NeedsVTEP", func() {
+			It("should return true when BPF routing without legacy fallback or VTEP", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "BPF",
+					LegacyHostRoutingEnabled: false,
+					VTEPEnabled:              false,
+				}
+				Expect(config.NeedsVTEP()).To(BeTrue())
+			})
+
+			It("should return false when legacy host routing is enabled", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "BPF",
+					LegacyHostRoutingEnabled: true,
+					VTEPEnabled:              false,
+				}
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+
+			It("should return false when VTEP is already enabled", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "BPF",
+					LegacyHostRoutingEnabled: false,
+					VTEPEnabled:              true,
+				}
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+
+			It("should return false when using legacy routing mode", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "Legacy",
+					LegacyHostRoutingEnabled: false,
+					VTEPEnabled:              false,
+				}
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+		})
+
+		Describe("IsLegacyHostRoutingEnabled", func() {
+			It("should return true when legacy host routing is enabled", func() {
+				config := &Config{
+					LegacyHostRoutingEnabled: true,
+				}
+				Expect(config.IsLegacyHostRoutingEnabled()).To(BeTrue())
+			})
+
+			It("should return false when legacy host routing is disabled", func() {
+				config := &Config{
+					LegacyHostRoutingEnabled: false,
+				}
+				Expect(config.IsLegacyHostRoutingEnabled()).To(BeFalse())
+			})
+		})
+	})
+
+	Context("DetectConfig", func() {
+		AfterEach(func() {
+			deleteCiliumConfigMap(ctx, k8sClient)
+		})
+
+		When("cilium-config ConfigMap does not exist", func() {
+			It("should return config with Detected=false", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeFalse())
+			})
+		})
+
+		When("cilium-config ConfigMap exists with native routing", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode":            "native",
+					"kube-proxy-replacement":  "true",
+					"enable-bpf-masquerade":   "true",
+					"bpf-host-legacy-routing": "false",
+					"enable-vtep":             "false",
+				})
+			})
+
+			It("should detect Cilium with BPF host routing", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.HostRoutingMode).To(Equal(HostRoutingModeBPF))
+				Expect(config.KubeProxyReplacement).To(BeTrue())
+				Expect(config.BPFMasqueradeEnabled).To(BeTrue())
+				Expect(config.LegacyHostRoutingEnabled).To(BeFalse())
+				Expect(config.VTEPEnabled).To(BeFalse())
+			})
+		})
+
+		When("cilium-config ConfigMap exists with tunnel routing", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode": "tunnel",
+				})
+			})
+
+			It("should detect Cilium with legacy host routing", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.HostRoutingMode).To(Equal(HostRoutingModeLegacy))
+			})
+		})
+
+		When("cilium-config has legacy host routing enabled", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode":            "native",
+					"bpf-host-legacy-routing": "true",
+				})
+			})
+
+			It("should detect legacy host routing fallback", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.LegacyHostRoutingEnabled).To(BeTrue())
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+		})
+
+		When("cilium-config has VTEP enabled", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode": "native",
+					"enable-vtep":  "true",
+				})
+			})
+
+			It("should detect VTEP is enabled", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.VTEPEnabled).To(BeTrue())
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+		})
+
+		When("cilium-config implies BPF from kube-proxy replacement", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"kube-proxy-replacement": "strict",
+				})
+			})
+
+			It("should infer BPF host routing", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.HostRoutingMode).To(Equal(HostRoutingModeBPF))
+				Expect(config.KubeProxyReplacement).To(BeTrue())
+			})
+		})
+	})
+
+	Context("DetectAndLog", func() {
+		AfterEach(func() {
+			deleteCiliumConfigMap(ctx, k8sClient)
+		})
+
+		It("should detect and log when Cilium is not present", func() {
+			config, err := DetectAndLog(ctx, k8sClient)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Detected).To(BeFalse())
+		})
+
+		It("should detect and log BPF host routing configuration", func() {
+			createCiliumConfigMap(ctx, k8sClient, map[string]string{
+				"routing-mode":           "native",
+				"kube-proxy-replacement": "true",
+			})
+
+			config, err := DetectAndLog(ctx, k8sClient)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Detected).To(BeTrue())
+			Expect(config.IsBPFHostRouting()).To(BeTrue())
+		})
+	})
+})

--- a/pkg/fabric/cilium/doc.go
+++ b/pkg/fabric/cilium/doc.go
@@ -1,0 +1,47 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cilium provides Cilium CNI integration for Liqo multi-cluster networking.
+//
+// # Problem
+//
+// Cilium with eBPF host routing (routing-mode: native) bypasses kernel routing
+// tables entirely. This breaks Liqo's network fabric, which relies on ip rules
+// and custom routing tables to direct cross-cluster traffic through WireGuard.
+//
+// # Solution
+//
+// Two integration strategies, auto-selected at startup:
+//
+//  1. VTEP Integration - Populates Cilium's VTEP configuration in the
+//     cilium-config ConfigMap with gateway pod endpoints, remote CIDRs,
+//     netmasks, and deterministic MAC addresses.
+//  2. IPCache Injection - Injects remote pod CIDRs into Cilium's ipcache
+//     via CiliumNode annotations.
+//
+// If bpf.hostLegacyRouting=true is set in Cilium, kernel routing works
+// normally and no Liqo-side changes are needed.
+//
+// CiliumLocalRedirectPolicy (LRP) was evaluated but does not support CIDR-based
+// matching, only single IPs. It cannot be used for cross-cluster pod CIDR routing.
+//
+// # Usage
+//
+// Automatically enabled when Cilium is detected (cilium-config ConfigMap exists)
+// with eBPF host routing. No manual configuration required.
+//
+// # References
+//
+//   - GitHub Issue: https://github.com/liqotech/liqo/issues/2166
+package cilium

--- a/pkg/fabric/cilium/ipcache_controller.go
+++ b/pkg/fabric/cilium/ipcache_controller.go
@@ -1,0 +1,358 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+const (
+	// IPCacheControllerFinalizer is the finalizer for ipcache cleanup.
+	IPCacheControllerFinalizer = "liqo.io/cilium-ipcache-controller"
+	// IPCacheControllerName is the controller name.
+	IPCacheControllerName = "cilium-ipcache-controller"
+	// LiqoRemoteCIDRAnnotationPrefix is the prefix for remote CIDR annotations.
+	LiqoRemoteCIDRAnnotationPrefix = "liqo.io/remote-cidr-"
+)
+
+// CiliumNodeGVR is the GroupVersionResource for CiliumNode.
+var CiliumNodeGVR = schema.GroupVersionResource{
+	Group:    "cilium.io",
+	Version:  "v2",
+	Resource: "ciliumnodes",
+}
+
+// RemoteCIDREntry represents a Liqo remote CIDR entry for ipcache injection.
+type RemoteCIDREntry struct {
+	// CIDR is the remote pod CIDR (e.g., "10.244.0.0/16").
+	CIDR string `json:"cidr"`
+	// TunnelEndpoint is the gateway pod IP that handles traffic for this CIDR.
+	TunnelEndpoint string `json:"tunnelEndpoint"`
+	// RemoteClusterID is the ID of the remote cluster.
+	RemoteClusterID string `json:"remoteClusterID"`
+	// Identity is the Cilium security identity (optional, defaults to world).
+	Identity uint32 `json:"identity,omitempty"`
+}
+
+// IPCacheReconciler manages Cilium ipcache entries for Liqo remote CIDRs.
+// When Cilium eBPF host routing is enabled, kernel routing tables are bypassed.
+// This controller injects remote pod CIDRs into Cilium's ipcache so that
+// eBPF can route cross-cluster traffic correctly.
+type IPCacheReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	EventsRecorder record.EventRecorder
+	Config         *Config
+	DynamicClient  dynamic.Interface
+	LocalNodeName  string
+}
+
+// NewIPCacheReconciler creates a new IPCacheReconciler.
+func NewIPCacheReconciler(
+	cl client.Client,
+	scheme *runtime.Scheme,
+	recorder record.EventRecorder,
+	ciliumConfig *Config,
+	cfg *rest.Config,
+	nodeName string,
+) (*IPCacheReconciler, error) {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return &IPCacheReconciler{
+		Client:         cl,
+		Scheme:         scheme,
+		EventsRecorder: recorder,
+		Config:         ciliumConfig,
+		DynamicClient:  dynClient,
+		LocalNodeName:  nodeName,
+	}, nil
+}
+
+// +kubebuilder:rbac:groups=networking.liqo.io,resources=configurations,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=cilium.io,resources=ciliumnodes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile handles Configuration events and manages Cilium ipcache entries.
+func (r *IPCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(4).Infof("Reconciling Configuration %s for Cilium ipcache", req.NamespacedName)
+
+	// Skip if Cilium doesn't need ipcache injection.
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.V(4).Info("Cilium eBPF host routing not detected, skipping ipcache injection")
+		return ctrl.Result{}, nil
+	}
+
+	// Get the Configuration.
+	cfg := &networkingv1beta1.Configuration{}
+	if err := r.Get(ctx, req.NamespacedName, cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("unable to get Configuration: %w", err)
+	}
+
+	// Handle deletion.
+	if !cfg.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, cfg)
+	}
+
+	// Add finalizer if not present.
+	if !controllerutil.ContainsFinalizer(cfg, IPCacheControllerFinalizer) {
+		controllerutil.AddFinalizer(cfg, IPCacheControllerFinalizer)
+		if err := r.Update(ctx, cfg); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Get remote cluster ID.
+	remoteClusterID := cfg.Labels[consts.RemoteClusterID]
+	if remoteClusterID == "" {
+		klog.V(4).Infof("Remote cluster ID not set for Configuration %s", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// Get remote pod CIDR.
+	remotePodCIDR := r.getRemotePodCIDR(cfg)
+	if remotePodCIDR == "" {
+		klog.V(4).Infof("Remote pod CIDR not yet available for Configuration %s", req.NamespacedName)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Get gateway pod IP (tunnel endpoint for this remote cluster).
+	gatewayIP, err := r.getGatewayPodIP(ctx, cfg.Namespace, remoteClusterID)
+	if err != nil {
+		klog.Warningf("Gateway pod IP not available for %s: %v", remoteClusterID, err)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Inject ipcache entry.
+	entry := &RemoteCIDREntry{
+		CIDR:            remotePodCIDR,
+		TunnelEndpoint:  gatewayIP,
+		RemoteClusterID: remoteClusterID,
+		Identity:        2, // Reserved identity for world (cross-cluster traffic).
+	}
+
+	if err := r.injectIPCacheEntry(ctx, entry); err != nil {
+		r.EventsRecorder.Event(cfg, corev1.EventTypeWarning, "IPCacheInjectionFailed",
+			fmt.Sprintf("Failed to inject ipcache entry for %s: %v", remotePodCIDR, err))
+		return ctrl.Result{}, fmt.Errorf("failed to inject ipcache entry: %w", err)
+	}
+
+	klog.Infof("Injected Cilium ipcache entry: %s via gateway %s (cluster: %s)",
+		remotePodCIDR, gatewayIP, remoteClusterID)
+	r.EventsRecorder.Event(cfg, corev1.EventTypeNormal, "IPCacheInjected",
+		fmt.Sprintf("Injected ipcache entry: %s via %s", remotePodCIDR, gatewayIP))
+
+	return ctrl.Result{}, nil
+}
+
+// handleDeletion removes ipcache entries when Configuration is deleted.
+func (r *IPCacheReconciler) handleDeletion(
+	ctx context.Context, cfg *networkingv1beta1.Configuration,
+) (ctrl.Result, error) {
+	klog.V(2).Infof("Handling deletion of Configuration %s/%s", cfg.Namespace, cfg.Name)
+
+	remoteClusterID := cfg.Labels[consts.RemoteClusterID]
+	remotePodCIDR := r.getRemotePodCIDR(cfg)
+
+	if remoteClusterID != "" && remotePodCIDR != "" {
+		if err := r.removeIPCacheEntry(ctx, remotePodCIDR, remoteClusterID); err != nil {
+			klog.Warningf("Failed to remove ipcache entry for %s: %v", remotePodCIDR, err)
+			// Continue with finalizer removal even if ipcache cleanup fails.
+		} else {
+			klog.Infof("Removed Cilium ipcache entry for %s", remotePodCIDR)
+		}
+	}
+
+	// Remove finalizer.
+	controllerutil.RemoveFinalizer(cfg, IPCacheControllerFinalizer)
+	if err := r.Update(ctx, cfg); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// injectIPCacheEntry adds a remote CIDR to Cilium's routing via CiliumNode annotation.
+func (r *IPCacheReconciler) injectIPCacheEntry(ctx context.Context, entry *RemoteCIDREntry) error {
+	// Get the local CiliumNode.
+	ciliumNode, err := r.DynamicClient.Resource(CiliumNodeGVR).Get(ctx, r.LocalNodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get CiliumNode %s: %w", r.LocalNodeName, err)
+	}
+
+	// Prepare annotation.
+	annotations := ciliumNode.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// Create annotation key based on CIDR hash.
+	annotationKey := LiqoRemoteCIDRAnnotationPrefix + hashCIDR(entry.CIDR)
+
+	// Serialize entry to JSON.
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal entry: %w", err)
+	}
+
+	annotations[annotationKey] = string(entryJSON)
+	ciliumNode.SetAnnotations(annotations)
+
+	// Update CiliumNode.
+	_, err = r.DynamicClient.Resource(CiliumNodeGVR).Update(ctx, ciliumNode, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update CiliumNode: %w", err)
+	}
+
+	return nil
+}
+
+// removeIPCacheEntry removes a remote CIDR annotation from CiliumNode.
+func (r *IPCacheReconciler) removeIPCacheEntry(ctx context.Context, cidr, _ string) error {
+	ciliumNode, err := r.DynamicClient.Resource(CiliumNodeGVR).Get(
+		ctx, r.LocalNodeName, metav1.GetOptions{},
+	)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // Node gone, nothing to clean up.
+		}
+		return fmt.Errorf("failed to get CiliumNode: %w", err)
+	}
+
+	annotations := ciliumNode.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+
+	annotationKey := LiqoRemoteCIDRAnnotationPrefix + hashCIDR(cidr)
+	if _, exists := annotations[annotationKey]; !exists {
+		return nil
+	}
+
+	delete(annotations, annotationKey)
+	ciliumNode.SetAnnotations(annotations)
+
+	_, err = r.DynamicClient.Resource(CiliumNodeGVR).Update(ctx, ciliumNode, metav1.UpdateOptions{})
+	return err
+}
+
+// getRemotePodCIDR extracts remote pod CIDR from Configuration.
+func (r *IPCacheReconciler) getRemotePodCIDR(cfg *networkingv1beta1.Configuration) string {
+	if cfg.Status.Remote == nil {
+		return ""
+	}
+	if len(cfg.Status.Remote.CIDR.Pod) == 0 {
+		return ""
+	}
+	return string(cfg.Status.Remote.CIDR.Pod[0])
+}
+
+// getGatewayPodIP finds the gateway pod IP for a remote cluster.
+func (r *IPCacheReconciler) getGatewayPodIP(
+	ctx context.Context, namespace, remoteClusterID string,
+) (string, error) {
+	// List gateway pods for this remote cluster.
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+			consts.RemoteClusterID:      remoteClusterID,
+		},
+	}
+
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return "", fmt.Errorf("failed to list gateway pods: %w", err)
+	}
+
+	// Find running gateway pod.
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			return pod.Status.PodIP, nil
+		}
+	}
+
+	// Fallback: try to get gateway IP from InternalFabric.
+	return r.getGatewayIPFromInternalFabric(ctx, namespace, remoteClusterID)
+}
+
+// getGatewayIPFromInternalFabric gets gateway IP from InternalFabric resource.
+func (r *IPCacheReconciler) getGatewayIPFromInternalFabric(
+	ctx context.Context, namespace, remoteClusterID string,
+) (string, error) {
+	// InternalFabric stores the gateway pod IP.
+	internalFabric := &networkingv1beta1.InternalFabric{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      remoteClusterID,
+	}, internalFabric); err != nil {
+		return "", fmt.Errorf("failed to get InternalFabric: %w", err)
+	}
+
+	if internalFabric.Spec.GatewayIP == "" {
+		return "", fmt.Errorf("gateway IP not set in InternalFabric")
+	}
+
+	return string(internalFabric.Spec.GatewayIP), nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *IPCacheReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.Info("Cilium eBPF host routing not detected, skipping ipcache controller setup")
+		return nil
+	}
+
+	klog.Info("Setting up Cilium ipcache controller for cross-cluster CIDR injection")
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(consts.CtrlInternalFabricFabric + "-cilium-ipcache").
+		For(&networkingv1beta1.Configuration{}).
+		Complete(r)
+}
+
+// hashCIDR creates a short hash of a CIDR for use in annotation keys.
+func hashCIDR(cidr string) string {
+	h := sha256.Sum256([]byte(cidr))
+	return hex.EncodeToString(h[:8])
+}

--- a/pkg/fabric/cilium/ipcache_controller_test.go
+++ b/pkg/fabric/cilium/ipcache_controller_test.go
@@ -1,0 +1,216 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+var _ = Describe("IPCache Controller", func() {
+	var (
+		reconciler *IPCacheReconciler
+		ciliumCfg  *Config
+	)
+
+	BeforeEach(func() {
+		ciliumCfg = &Config{
+			Detected:        true,
+			HostRoutingMode: HostRoutingModeBPF,
+			LRPSupported:    true,
+		}
+	})
+
+	Context("RemoteCIDREntry", func() {
+		Describe("JSON serialization", func() {
+			It("should serialize entry to JSON correctly", func() {
+				entry := &RemoteCIDREntry{
+					CIDR:            remotePodCIDR,
+					TunnelEndpoint:  gatewayIP,
+					RemoteClusterID: remoteClusterID,
+					Identity:        2,
+				}
+				Expect(entry.CIDR).To(Equal(remotePodCIDR))
+				Expect(entry.TunnelEndpoint).To(Equal(gatewayIP))
+				Expect(entry.RemoteClusterID).To(Equal(remoteClusterID))
+				Expect(entry.Identity).To(Equal(uint32(2)))
+			})
+		})
+	})
+
+	Context("hashCIDR", func() {
+		It("should generate consistent hash for same CIDR", func() {
+			hash1 := hashCIDR("10.244.0.0/16")
+			hash2 := hashCIDR("10.244.0.0/16")
+			Expect(hash1).To(Equal(hash2))
+		})
+
+		It("should generate different hashes for different CIDRs", func() {
+			hash1 := hashCIDR("10.244.0.0/16")
+			hash2 := hashCIDR("10.245.0.0/16")
+			Expect(hash1).ToNot(Equal(hash2))
+		})
+
+		It("should generate 16-character hex hash", func() {
+			hash := hashCIDR("10.244.0.0/16")
+			Expect(len(hash)).To(Equal(16))
+		})
+	})
+
+	Context("getRemotePodCIDR", func() {
+		It("should return empty string when Status.Remote is nil", func() {
+			reconciler = &IPCacheReconciler{}
+			cfg := &networkingv1beta1.Configuration{
+				Status: networkingv1beta1.ConfigurationStatus{
+					Remote: nil,
+				},
+			}
+			cidr := reconciler.getRemotePodCIDR(cfg)
+			Expect(cidr).To(BeEmpty())
+		})
+
+		It("should return empty string when Pod CIDR list is empty", func() {
+			reconciler = &IPCacheReconciler{}
+			cfg := &networkingv1beta1.Configuration{
+				Status: networkingv1beta1.ConfigurationStatus{
+					Remote: &networkingv1beta1.ClusterConfig{
+						CIDR: networkingv1beta1.ClusterConfigCIDR{
+							Pod: []networkingv1beta1.CIDR{},
+						},
+					},
+				},
+			}
+			cidr := reconciler.getRemotePodCIDR(cfg)
+			Expect(cidr).To(BeEmpty())
+		})
+
+		It("should return first pod CIDR when available", func() {
+			reconciler = &IPCacheReconciler{}
+			cfg := &networkingv1beta1.Configuration{
+				Status: networkingv1beta1.ConfigurationStatus{
+					Remote: &networkingv1beta1.ClusterConfig{
+						CIDR: networkingv1beta1.ClusterConfigCIDR{
+							Pod: []networkingv1beta1.CIDR{
+								networkingv1beta1.CIDR(remotePodCIDR),
+								networkingv1beta1.CIDR("10.245.0.0/16"),
+							},
+						},
+					},
+				},
+			}
+			cidr := reconciler.getRemotePodCIDR(cfg)
+			Expect(cidr).To(Equal(remotePodCIDR))
+		})
+	})
+
+	Context("Gateway pod discovery", func() {
+		var gatewayPod *corev1.Pod
+
+		BeforeEach(func() {
+			reconciler = &IPCacheReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+				Config: ciliumCfg,
+			}
+
+			gatewayPod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "liqo-gateway-ipcache-" + remoteClusterID,
+					Namespace: "liqo",
+					Labels: map[string]string{
+						gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+						consts.RemoteClusterID:      remoteClusterID,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "gateway",
+							Image: "liqo/gateway:latest",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gatewayPod)).To(Succeed())
+
+			// Status is a subresource - must be updated separately.
+			gatewayPod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: gatewayIP,
+			}
+			Expect(k8sClient.Status().Update(ctx, gatewayPod)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, gatewayPod)
+		})
+
+		Describe("getGatewayPodIP", func() {
+			It("should find gateway pod IP for remote cluster", func() {
+				ip, err := reconciler.getGatewayPodIP(ctx, "liqo", remoteClusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ip).To(Equal(gatewayIP))
+			})
+
+			It("should return error when no gateway pod exists", func() {
+				_, err := reconciler.getGatewayPodIP(ctx, "liqo", "non-existent-cluster")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("Reconciler setup", func() {
+		Describe("SetupWithManager", func() {
+			It("should skip setup when Cilium not detected", func() {
+				r := &IPCacheReconciler{
+					Client: k8sClient,
+					Scheme: scheme.Scheme,
+					Config: nil,
+				}
+				Expect(r.Config).To(BeNil())
+			})
+
+			It("should skip setup when not using BPF host routing", func() {
+				cfg := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeLegacy,
+				}
+				r := &IPCacheReconciler{
+					Client: k8sClient,
+					Scheme: scheme.Scheme,
+					Config: cfg,
+				}
+				Expect(r.Config.IsBPFHostRouting()).To(BeFalse())
+			})
+		})
+	})
+
+	Context("Annotation key generation", func() {
+		It("should generate valid annotation key with prefix", func() {
+			cidr := "10.244.0.0/16"
+			hash := hashCIDR(cidr)
+			annotationKey := LiqoRemoteCIDRAnnotationPrefix + hash
+			Expect(annotationKey).To(HavePrefix(LiqoRemoteCIDRAnnotationPrefix))
+			Expect(len(annotationKey)).To(Equal(len(LiqoRemoteCIDRAnnotationPrefix) + 16))
+		})
+	})
+})

--- a/pkg/fabric/cilium/suite_test.go
+++ b/pkg/fabric/cilium/suite_test.go
@@ -1,0 +1,115 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+const (
+	remoteClusterID = "remote-cluster-id"
+	remotePodCIDR   = "10.244.0.0/16"
+	gatewayIP       = "10.109.0.89"
+)
+
+func TestCilium(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cilium Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	ctx, cancel = context.WithCancel(context.Background())
+	testutil.LogsToGinkgoWriter()
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	Expect(corev1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(networkingv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(liqov1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	// Use a direct (non-cached) client for deterministic test setup/teardown.
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	// Create required namespaces.
+	for _, ns := range []string{"kube-system", "liqo"} {
+		Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}))).To(Succeed())
+	}
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// createCiliumConfigMap creates a cilium-config ConfigMap with the given data.
+func createCiliumConfigMap(ctx context.Context, cl client.Client, data map[string]string) {
+	deleteCiliumConfigMap(ctx, cl)
+	Expect(cl.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CiliumConfigMapName,
+			Namespace: CiliumNamespace,
+		},
+		Data: data,
+	})).To(Succeed())
+}
+
+// deleteCiliumConfigMap deletes the cilium-config ConfigMap if it exists.
+func deleteCiliumConfigMap(ctx context.Context, cl client.Client) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CiliumConfigMapName,
+			Namespace: CiliumNamespace,
+		},
+	}
+	Expect(client.IgnoreNotFound(cl.Delete(ctx, cm))).To(Succeed())
+}

--- a/pkg/fabric/cilium/vtep_controller.go
+++ b/pkg/fabric/cilium/vtep_controller.go
@@ -1,0 +1,386 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+const (
+	// VTEPControllerFinalizer is the finalizer for VTEP cleanup.
+	VTEPControllerFinalizer = "liqo.io/cilium-vtep-controller"
+	// VTEPControllerName is the controller name.
+	VTEPControllerName = "cilium-vtep-controller"
+
+	// VTEP ConfigMap keys.
+	vtepEnabledKey  = "enable-vtep"
+	vtepEndpointKey = "vtep-endpoint"
+	vtepCIDRKey     = "vtep-cidr"
+	vtepMaskKey     = "vtep-mask"
+	vtepMACKey      = "vtep-mac"
+
+	// LiqoVTEPAnnotation marks Liqo-managed VTEP entries.
+	LiqoVTEPAnnotation = "liqo.io/vtep-managed"
+
+	// defaultGatewayMAC is the fallback MAC address when gateway IP cannot be parsed.
+	defaultGatewayMAC = "82:36:00:00:00:00"
+)
+
+// VTEPEntry represents a VTEP configuration entry for Cilium.
+type VTEPEntry struct {
+	// Endpoint is the gateway pod IP (VTEP device IP).
+	Endpoint string
+	// CIDR is the remote pod CIDR routed via this VTEP.
+	CIDR string
+	// Mask is the netmask for the CIDR.
+	Mask string
+	// MAC is the gateway pod's MAC address.
+	MAC string
+	// RemoteClusterID identifies the remote cluster.
+	RemoteClusterID string
+}
+
+// VTEPReconciler manages Cilium VTEP configuration for Liqo remote CIDRs.
+// When Cilium eBPF host routing is enabled, kernel routing tables are bypassed.
+// This controller configures Cilium's VTEP integration to route remote pod CIDRs
+// through Liqo gateway pods, enabling cross-cluster connectivity.
+type VTEPReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	EventsRecorder record.EventRecorder
+	Config         *Config
+}
+
+// NewVTEPReconciler creates a new VTEPReconciler.
+func NewVTEPReconciler(
+	cl client.Client,
+	scheme *runtime.Scheme,
+	recorder record.EventRecorder,
+	ciliumConfig *Config,
+) *VTEPReconciler {
+	return &VTEPReconciler{
+		Client:         cl,
+		Scheme:         scheme,
+		EventsRecorder: recorder,
+		Config:         ciliumConfig,
+	}
+}
+
+// +kubebuilder:rbac:groups=networking.liqo.io,resources=configurations,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;patch,namespace=kube-system
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile handles Configuration events and manages Cilium VTEP configuration.
+func (r *VTEPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(4).Infof("Reconciling Configuration %s for Cilium VTEP", req.NamespacedName)
+
+	// Skip if Cilium doesn't need VTEP integration.
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.V(4).Info("Cilium eBPF host routing not detected, skipping VTEP configuration")
+		return ctrl.Result{}, nil
+	}
+
+	// Get the Configuration.
+	cfg := &networkingv1beta1.Configuration{}
+	if err := r.Get(ctx, req.NamespacedName, cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Configuration deleted - rebuild VTEP config from remaining Configurations.
+			return r.rebuildVTEPConfig(ctx)
+		}
+		return ctrl.Result{}, fmt.Errorf("unable to get Configuration: %w", err)
+	}
+
+	// Handle deletion.
+	if !cfg.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, cfg)
+	}
+
+	// Add finalizer if not present.
+	if !controllerutil.ContainsFinalizer(cfg, VTEPControllerFinalizer) {
+		controllerutil.AddFinalizer(cfg, VTEPControllerFinalizer)
+		if err := r.Update(ctx, cfg); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Rebuild VTEP configuration with all current Configurations.
+	return r.rebuildVTEPConfig(ctx)
+}
+
+// handleDeletion removes VTEP entries when Configuration is deleted.
+func (r *VTEPReconciler) handleDeletion(
+	ctx context.Context, cfg *networkingv1beta1.Configuration,
+) (ctrl.Result, error) {
+	klog.V(2).Infof("Handling deletion of Configuration %s/%s", cfg.Namespace, cfg.Name)
+
+	// Remove finalizer first.
+	controllerutil.RemoveFinalizer(cfg, VTEPControllerFinalizer)
+	if err := r.Update(ctx, cfg); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	// Rebuild VTEP config without this Configuration.
+	return r.rebuildVTEPConfig(ctx)
+}
+
+// rebuildVTEPConfig collects all VTEP entries from active Configurations
+// and updates the Cilium ConfigMap.
+func (r *VTEPReconciler) rebuildVTEPConfig(ctx context.Context) (ctrl.Result, error) {
+	// List all Configurations.
+	configList := &networkingv1beta1.ConfigurationList{}
+	if err := r.List(ctx, configList); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list Configurations: %w", err)
+	}
+
+	// Collect VTEP entries from each Configuration.
+	var entries []VTEPEntry
+	for i := range configList.Items {
+		cfg := &configList.Items[i]
+		// Skip if being deleted.
+		if !cfg.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		entry, err := r.buildVTEPEntry(ctx, cfg)
+		if err != nil {
+			klog.V(4).Infof("Skipping Configuration %s/%s: %v", cfg.Namespace, cfg.Name, err)
+			continue
+		}
+
+		entries = append(entries, *entry)
+	}
+
+	// Update Cilium ConfigMap.
+	if err := r.updateConfig(ctx, entries); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update Cilium config: %w", err)
+	}
+
+	if len(entries) > 0 {
+		klog.Infof("Updated Cilium VTEP configuration with %d entries", len(entries))
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// buildVTEPEntry creates a VTEPEntry from a Configuration resource.
+func (r *VTEPReconciler) buildVTEPEntry(
+	ctx context.Context, cfg *networkingv1beta1.Configuration,
+) (*VTEPEntry, error) {
+	// Get remote cluster ID.
+	remoteClusterID := cfg.Labels[consts.RemoteClusterID]
+	if remoteClusterID == "" {
+		return nil, fmt.Errorf("remote cluster ID not set")
+	}
+
+	// Get remote pod CIDR.
+	if cfg.Status.Remote == nil || len(cfg.Status.Remote.CIDR.Pod) == 0 {
+		return nil, fmt.Errorf("remote pod CIDR not available")
+	}
+	remotePodCIDR := string(cfg.Status.Remote.CIDR.Pod[0])
+
+	// Get gateway pod IP and MAC.
+	gatewayIP, gatewayMAC, err := r.getGatewayPodInfo(ctx, cfg.Namespace, remoteClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("gateway pod info not available: %w", err)
+	}
+
+	// Calculate netmask from CIDR.
+	_, ipNet, err := net.ParseCIDR(remotePodCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CIDR %s: %w", remotePodCIDR, err)
+	}
+	mask := net.IP(ipNet.Mask).String()
+
+	return &VTEPEntry{
+		Endpoint:        gatewayIP,
+		CIDR:            remotePodCIDR,
+		Mask:            mask,
+		MAC:             gatewayMAC,
+		RemoteClusterID: remoteClusterID,
+	}, nil
+}
+
+// getGatewayPodInfo retrieves the gateway pod's IP and MAC address.
+func (r *VTEPReconciler) getGatewayPodInfo(
+	ctx context.Context, namespace, remoteClusterID string,
+) (ip, mac string, err error) {
+	// List gateway pods for this remote cluster.
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+			consts.RemoteClusterID:      remoteClusterID,
+		},
+	}
+
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return "", "", fmt.Errorf("failed to list gateway pods: %w", err)
+	}
+
+	// Find running gateway pod.
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			// Get MAC address from pod annotations or generate deterministic one.
+			mac := r.getGatewayMAC(pod)
+			return pod.Status.PodIP, mac, nil
+		}
+	}
+
+	// Fallback: try to get gateway IP from InternalFabric.
+	return r.getGatewayIPFromInternalFabric(ctx, namespace, remoteClusterID)
+}
+
+// getGatewayMAC retrieves or generates a MAC address for the gateway pod.
+func (r *VTEPReconciler) getGatewayMAC(pod *corev1.Pod) string {
+	// Check for MAC annotation.
+	if mac, ok := pod.Annotations["liqo.io/gateway-mac"]; ok {
+		return mac
+	}
+
+	// Generate deterministic MAC from pod IP.
+	// Format: 82:36:xx:xx:xx:xx where xx are derived from IP.
+	ip := net.ParseIP(pod.Status.PodIP)
+	if ip == nil {
+		return defaultGatewayMAC
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return defaultGatewayMAC
+	}
+
+	return fmt.Sprintf("82:36:%02x:%02x:%02x:%02x", ip4[0], ip4[1], ip4[2], ip4[3])
+}
+
+// getGatewayIPFromInternalFabric gets gateway IP from InternalFabric resource.
+func (r *VTEPReconciler) getGatewayIPFromInternalFabric(
+	ctx context.Context, namespace, remoteClusterID string,
+) (gatewayIP, gatewayMAC string, err error) {
+	internalFabric := &networkingv1beta1.InternalFabric{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      remoteClusterID,
+	}, internalFabric); err != nil {
+		return "", "", fmt.Errorf("failed to get InternalFabric: %w", err)
+	}
+
+	if internalFabric.Spec.GatewayIP == "" {
+		return "", "", fmt.Errorf("gateway IP not set in InternalFabric")
+	}
+
+	gatewayIP = string(internalFabric.Spec.GatewayIP)
+	// Generate MAC from gateway IP.
+	ip := net.ParseIP(gatewayIP)
+	if ip == nil {
+		return gatewayIP, defaultGatewayMAC, nil
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return gatewayIP, defaultGatewayMAC, nil
+	}
+
+	gatewayMAC = fmt.Sprintf("82:36:%02x:%02x:%02x:%02x", ip4[0], ip4[1], ip4[2], ip4[3])
+	return gatewayIP, gatewayMAC, nil
+}
+
+// updateConfig updates the Cilium ConfigMap with VTEP entries.
+func (r *VTEPReconciler) updateConfig(ctx context.Context, entries []VTEPEntry) error {
+	// Get Cilium ConfigMap.
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: CiliumNamespace,
+		Name:      CiliumConfigMapName,
+	}, cm); err != nil {
+		return fmt.Errorf("failed to get Cilium ConfigMap: %w", err)
+	}
+
+	// Initialize data map if nil.
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+
+	// Build VTEP configuration strings.
+	if len(entries) == 0 {
+		// No entries - disable VTEP.
+		delete(cm.Data, vtepEnabledKey)
+		delete(cm.Data, vtepEndpointKey)
+		delete(cm.Data, vtepCIDRKey)
+		delete(cm.Data, vtepMaskKey)
+		delete(cm.Data, vtepMACKey)
+	} else {
+		// Enable VTEP with entries.
+		var endpoints, cidrs, masks, macs []string
+		for _, entry := range entries {
+			endpoints = append(endpoints, entry.Endpoint)
+			cidrs = append(cidrs, entry.CIDR)
+			masks = append(masks, entry.Mask)
+			macs = append(macs, entry.MAC)
+		}
+
+		cm.Data[vtepEnabledKey] = boolTrue
+		cm.Data[vtepEndpointKey] = strings.Join(endpoints, " ")
+		cm.Data[vtepCIDRKey] = strings.Join(cidrs, " ")
+		cm.Data[vtepMaskKey] = strings.Join(masks, " ")
+		cm.Data[vtepMACKey] = strings.Join(macs, " ")
+	}
+
+	// Update annotation to track Liqo management.
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	cm.Annotations[LiqoVTEPAnnotation] = boolTrue
+
+	// Update ConfigMap.
+	if err := r.Update(ctx, cm); err != nil {
+		return fmt.Errorf("failed to update Cilium ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VTEPReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.Info("Cilium eBPF host routing not detected, skipping VTEP controller setup")
+		return nil
+	}
+
+	klog.Info("Setting up Cilium VTEP controller for cross-cluster CIDR routing")
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(consts.CtrlInternalFabricFabric + "-cilium-vtep").
+		For(&networkingv1beta1.Configuration{}).
+		Complete(r)
+}

--- a/pkg/fabric/cilium/vtep_controller_test.go
+++ b/pkg/fabric/cilium/vtep_controller_test.go
@@ -1,0 +1,301 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+var _ = Describe("VTEP Controller", func() {
+	var (
+		reconciler *VTEPReconciler
+		ciliumCfg  *Config
+	)
+
+	BeforeEach(func() {
+		ciliumCfg = &Config{
+			Detected:        true,
+			HostRoutingMode: HostRoutingModeBPF,
+		}
+		reconciler = NewVTEPReconciler(
+			k8sClient,
+			scheme.Scheme,
+			nil, // No event recorder needed for tests.
+			ciliumCfg,
+		)
+	})
+
+	Context("VTEPEntry construction", func() {
+		Describe("getGatewayMAC", func() {
+			It("should generate deterministic MAC from pod IP", func() {
+				pod := &corev1.Pod{
+					Status: corev1.PodStatus{
+						PodIP: "10.109.0.89",
+					},
+				}
+				mac := reconciler.getGatewayMAC(pod)
+				Expect(mac).To(Equal("82:36:0a:6d:00:59"))
+			})
+
+			It("should use annotation MAC if present", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"liqo.io/gateway-mac": "aa:bb:cc:dd:ee:ff",
+						},
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.109.0.89",
+					},
+				}
+				mac := reconciler.getGatewayMAC(pod)
+				Expect(mac).To(Equal("aa:bb:cc:dd:ee:ff"))
+			})
+
+			It("should return default MAC for invalid IP", func() {
+				pod := &corev1.Pod{
+					Status: corev1.PodStatus{
+						PodIP: "invalid",
+					},
+				}
+				mac := reconciler.getGatewayMAC(pod)
+				Expect(mac).To(Equal("82:36:00:00:00:00"))
+			})
+		})
+	})
+
+	Context("VTEP ConfigMap updates", func() {
+		AfterEach(func() {
+			deleteCiliumConfigMap(ctx, k8sClient)
+		})
+
+		Describe("updateConfig", func() {
+			BeforeEach(func() {
+				// Create initial cilium-config.
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode": "native",
+				})
+			})
+
+			It("should enable VTEP with single entry", func() {
+				entries := []VTEPEntry{
+					{
+						Endpoint:        "10.109.0.89",
+						CIDR:            "10.244.0.0/16",
+						Mask:            "255.255.0.0",
+						MAC:             "82:36:0a:6d:00:59",
+						RemoteClusterID: remoteClusterID,
+					},
+				}
+
+				err := reconciler.updateConfig(ctx, entries)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify ConfigMap was updated.
+				cm := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      CiliumConfigMapName,
+					Namespace: CiliumNamespace,
+				}, cm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cm.Data["enable-vtep"]).To(Equal("true"))
+				Expect(cm.Data["vtep-endpoint"]).To(Equal("10.109.0.89"))
+				Expect(cm.Data["vtep-cidr"]).To(Equal("10.244.0.0/16"))
+				Expect(cm.Data["vtep-mask"]).To(Equal("255.255.0.0"))
+				Expect(cm.Data["vtep-mac"]).To(Equal("82:36:0a:6d:00:59"))
+				Expect(cm.Annotations[LiqoVTEPAnnotation]).To(Equal("true"))
+			})
+
+			It("should enable VTEP with multiple entries", func() {
+				entries := []VTEPEntry{
+					{
+						Endpoint:        "10.109.0.89",
+						CIDR:            "10.244.0.0/16",
+						Mask:            "255.255.0.0",
+						MAC:             "82:36:0a:6d:00:59",
+						RemoteClusterID: "cluster-1",
+					},
+					{
+						Endpoint:        "10.109.0.90",
+						CIDR:            "10.245.0.0/16",
+						Mask:            "255.255.0.0",
+						MAC:             "82:36:0a:6d:00:5a",
+						RemoteClusterID: "cluster-2",
+					},
+				}
+
+				err := reconciler.updateConfig(ctx, entries)
+				Expect(err).ToNot(HaveOccurred())
+
+				cm := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      CiliumConfigMapName,
+					Namespace: CiliumNamespace,
+				}, cm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cm.Data["vtep-endpoint"]).To(Equal("10.109.0.89 10.109.0.90"))
+				Expect(cm.Data["vtep-cidr"]).To(Equal("10.244.0.0/16 10.245.0.0/16"))
+			})
+
+			It("should disable VTEP when no entries", func() {
+				// First enable VTEP.
+				entries := []VTEPEntry{
+					{
+						Endpoint: "10.109.0.89",
+						CIDR:     "10.244.0.0/16",
+						Mask:     "255.255.0.0",
+						MAC:      "82:36:0a:6d:00:59",
+					},
+				}
+				err := reconciler.updateConfig(ctx, entries)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Then disable by passing empty entries.
+				err = reconciler.updateConfig(ctx, []VTEPEntry{})
+				Expect(err).ToNot(HaveOccurred())
+
+				cm := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      CiliumConfigMapName,
+					Namespace: CiliumNamespace,
+				}, cm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cm.Data).ToNot(HaveKey("enable-vtep"))
+				Expect(cm.Data).ToNot(HaveKey("vtep-endpoint"))
+			})
+		})
+	})
+
+	Context("Gateway pod discovery", func() {
+		var (
+			gatewayPod    *corev1.Pod
+			configuration *networkingv1beta1.Configuration
+		)
+
+		BeforeEach(func() {
+			// Create a gateway pod.
+			gatewayPod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "liqo-gateway-" + remoteClusterID,
+					Namespace: "liqo",
+					Labels: map[string]string{
+						gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+						consts.RemoteClusterID:      remoteClusterID,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "gateway",
+							Image: "liqo/gateway:latest",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gatewayPod)).To(Succeed())
+
+			// Status is a subresource - must be updated separately.
+			gatewayPod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: gatewayIP,
+			}
+			Expect(k8sClient.Status().Update(ctx, gatewayPod)).To(Succeed())
+
+			// Create a Configuration resource.
+			configuration = &networkingv1beta1.Configuration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "config-" + remoteClusterID,
+					Namespace: "liqo",
+					Labels: map[string]string{
+						consts.RemoteClusterID: remoteClusterID,
+					},
+				},
+				Spec: networkingv1beta1.ConfigurationSpec{},
+			}
+			Expect(k8sClient.Create(ctx, configuration)).To(Succeed())
+
+			// Update Configuration status with remote CIDR.
+			configuration.Status = networkingv1beta1.ConfigurationStatus{
+				Remote: &networkingv1beta1.ClusterConfig{
+					CIDR: networkingv1beta1.ClusterConfigCIDR{
+						Pod: []networkingv1beta1.CIDR{networkingv1beta1.CIDR(remotePodCIDR)},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, configuration)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, gatewayPod)
+			_ = k8sClient.Delete(ctx, configuration)
+		})
+
+		Describe("getGatewayPodInfo", func() {
+			It("should find gateway pod IP and generate MAC", func() {
+				ip, mac, err := reconciler.getGatewayPodInfo(ctx, "liqo", remoteClusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ip).To(Equal(gatewayIP))
+				// MAC generated from IP 10.109.0.89 = 82:36:0a:6d:00:59.
+				Expect(mac).To(Equal("82:36:0a:6d:00:59"))
+			})
+		})
+
+		Describe("buildVTEPEntry", func() {
+			It("should build VTEP entry from Configuration", func() {
+				entry, err := reconciler.buildVTEPEntry(ctx, configuration)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entry.Endpoint).To(Equal(gatewayIP))
+				Expect(entry.CIDR).To(Equal(remotePodCIDR))
+				Expect(entry.RemoteClusterID).To(Equal(remoteClusterID))
+
+				// Verify mask calculated correctly from CIDR.
+				_, ipNet, _ := net.ParseCIDR(remotePodCIDR)
+				expectedMask := net.IP(ipNet.Mask).String()
+				Expect(entry.Mask).To(Equal(expectedMask))
+			})
+		})
+	})
+
+	Context("Reconciler setup", func() {
+		Describe("SetupWithManager", func() {
+			It("should skip setup when Cilium not detected", func() {
+				r := NewVTEPReconciler(k8sClient, scheme.Scheme, nil, nil)
+				// This should not error, just skip setup.
+				// We can't easily test SetupWithManager without a full manager.
+				Expect(r.Config).To(BeNil())
+			})
+
+			It("should skip setup when not using BPF host routing", func() {
+				cfg := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeLegacy,
+				}
+				r := NewVTEPReconciler(k8sClient, scheme.Scheme, nil, cfg)
+				Expect(r.Config.IsBPFHostRouting()).To(BeFalse())
+			})
+		})
+	})
+})


### PR DESCRIPTION
This MR is part of a rework of https://github.com/liqotech/liqo/pull/3139; nailing down eBPF host routing strategies more clearly are the real meat of this work, and I totally understand if Cilium eBPF routing supportability - strategies provided here or otherwise -  *and/or* RKE2 support in general are ultimately outside the goals of Liqo. 


- Fixes liqotech/liqo#2166
- Sister PR in the works for RKE2 specific aspects of this are in the pipes here:  https://github.com/Jesssullivan/liqo/pull/5


---

When Cilium is configured with eBPF host routing (`routing-mode: native`), kernel routing tables are bypassed entirely. This breaks Liqo's network fabric, which relies on `ip rule` and custom routing tables to direct cross-cluster traffic through WireGuard tunnels.  I've Added automatic Cilium detection and two complementary integration strategies to `liqo-fabric`:

- VTEP— Populates Cilium's VTEP configuration in the `cilium-config` ConfigMap with gateway pod endpoints, remote CIDRs, and deterministic MAC addresses.
- IPCache— Annotates local `CiliumNode` resources with remote pod CIDRs and tunnel endpoints so eBPF is aware of cross-cluster routes.

Both controllers watch `Configuration` resources and activate only when Cilium eBPF host routing is detected. When `bpf.hostLegacyRouting=true`, kernel routing works normally and no changes are needed.


Notes on this:
- Cilium configuration is auto-detected at startup from the `cilium-config` ConfigMap — no manual flags required.
- A non-cached client is used for detection because the manager cache hasn't started yet.
- `CiliumNode` is accessed via dynamic client to avoid REST mapper races with Cilium CRDs.
- MAC addresses are generated deterministically from gateway pod IPs (`82:36:xx:xx:xx:xx`).
- `CiliumLocalRedirectPolicy` was evaluated but cannot be used — LRP only supports single IP matching, not CIDRs.


