### PR TITLE
feat(liqoctl): add RKE2 install provider and out-of-band peering support

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kind"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kubeadm"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/openshift"
+	"github.com/liqotech/liqo/pkg/liqoctl/install/rke2"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/utils"
 	"github.com/liqotech/liqo/pkg/liqoctl/version"
@@ -188,6 +189,7 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, kind.New))
 	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, kubeadm.New))
 	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, openshift.New))
+	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, rke2.New))
 
 	return cmd
 }

--- a/docs/usage/liqoctl/liqoctl_install.md
+++ b/docs/usage/liqoctl/liqoctl_install.md
@@ -1355,3 +1355,181 @@ liqoctl install openshift [flags]
 
 >The version of Liqo to be installed, among releases and commit SHAs. Defaults to the liqoctl version **(default "unknown")**
 
+## liqoctl install rke2
+
+Install Liqo in the selected rke2 cluster
+
+### Synopsis
+
+Install/upgrade Liqo in the selected rke2 cluster.
+
+This command wraps the Helm command to install/upgrade Liqo in the selected
+rke2 cluster, automatically retrieving most parameters based on the cluster
+configuration.
+
+Please, refer to the help of the root *liqoctl install* command for additional
+information and examples concerning its behavior and the common flags.
+
+
+
+```
+liqoctl install rke2 [flags]
+```
+
+### Examples
+
+
+```bash
+  $ liqoctl install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+```
+
+or
+
+```bash
+  $ liqoctl install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --pod-cidr 10.0.0.0/16 --service-cidr 10.1.0.0/16 \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+```
+
+or (with out-of-band peering for restricted networks)
+
+```bash
+  $ liqoctl install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-id my-rke2-cluster \
+      --cluster-labels region=us-west,environment=production
+```
+
+
+
+
+
+
+
+
+### Options
+`--api-server-url` _string_:
+
+>The Kubernetes API Server URL (defaults to the one specified in the kubeconfig)
+
+`--pod-cidr` _string_:
+
+>The Pod CIDR of the cluster **(default "10.42.0.0/16")**
+
+`--service-cidr` _string_:
+
+>The Service CIDR of the cluster **(default "10.43.0.0/16")**
+
+
+### Global options
+
+`--cluster` _string_:
+
+>The name of the kubeconfig cluster to use
+
+`--cluster-id` _clusterID_:
+
+>The id identifying the cluster in Liqo
+
+`--cluster-labels` _stringMap_:
+
+>The set of labels (i.e., key/value pairs, separated by comma) identifying the current cluster, and propagated to the virtual nodes
+
+`--context` _string_:
+
+>The name of the kubeconfig context to use
+
+`--disable-api-server-sanity-check`
+
+>Disable the sanity checks concerning the retrieved Kubernetes API server URL (default false)
+
+`--disable-kernel-version-check`
+
+>Disable the check of the minimum kernel version required to run the wireguard interface (default false)
+
+`--disable-telemetry`
+
+>Disable the anonymous and aggregated Liqo telemetry collection (default false)
+
+`--dry-run`
+
+>Simulate the installation process (default false)
+
+`--dump-values-path` _string_:
+
+>The path where the generated values file is saved (only in case --only-output-values is set). Default: './values.yaml'
+
+`--enable-metrics`
+
+>Enable metrics exposition through prometheus (default false)
+
+`--global-annotations` _stringToString_:
+
+>Global annotations to be added to all created resources (key=value)
+
+`--global-labels` _stringToString_:
+
+>Global labels to be added to all created resources (key=value)
+
+`--kubeconfig` _string_:
+
+>Path to the kubeconfig file to use for CLI requests
+
+`--local-chart-path` _string_:
+
+>The local path used to retrieve the Helm chart, instead of the upstream one
+
+`-n`, `--namespace` _string_:
+
+>The namespace where Liqo is installed in **(default "liqo")**
+
+`--only-output-values`
+
+>Generate the pre-configured values file for further customization, instead of installing Liqo (default false)
+
+`--repo-url` _string_:
+
+>The URL of the git repository used to retrieve the Helm chart, if a non released version is specified **(default "https://github.com/liqotech/liqo")**
+
+`--reserved-subnets` _cidrList_:
+
+>The private CIDRs to be excluded, as already in use (e.g., the subnet of the cluster nodes); PodCIDR and ServiceCIDR shall not be included.
+
+`--set` _stringArray_:
+
+>Set additional values on the command line (can specify multiple times or separate values with commas: key1=val1,key2=val2)
+
+`--set-string` _stringArray_:
+
+>Set additional string values on the command line (can specify multiple times or separate values with commas: key1=val1,key2=val2)
+
+`--skip-confirm`
+
+>Skip the confirmation prompt (suggested for automation)
+
+`--skip-validation`
+
+>Skip the validation of the arguments (PodCIDR, ServiceCIDR). This is useful when you are sure of what you are doing and the amount of pods and services in your cluster is very large (default false)
+
+`--timeout` _duration_:
+
+>The timeout for the completion of the installation process **(default 10m0s)**
+
+`--user` _string_:
+
+>The name of the kubeconfig user to use
+
+`--values` _stringArray_:
+
+>Specify values in a YAML file or a URL (can specify multiple)
+
+`-v`, `--verbose`
+
+>Enable verbose logs (default false)
+
+`--version` _string_:
+
+>The version of Liqo to be installed, among releases and commit SHAs. Defaults to the liqoctl version **(default "unknown")**
+

--- a/pkg/liqoctl/install/rke2/provider.go
+++ b/pkg/liqoctl/install/rke2/provider.go
@@ -1,0 +1,87 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rke2 implements the Liqo install provider for RKE2 clusters.
+package rke2
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/install"
+)
+
+var _ install.Provider = (*Options)(nil)
+
+// Options encapsulates the arguments of the install rke2 command.
+type Options struct {
+	*install.Options
+}
+
+// New initializes a new Provider object.
+func New(o *install.Options) install.Provider {
+	return &Options{Options: o}
+}
+
+// Name returns the name of the provider.
+func (o *Options) Name() string { return "rke2" }
+
+// Examples returns the examples string for the given provider.
+func (o *Options) Examples() string {
+	return `Examples:
+  $ {{ .Executable }} install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+or
+  $ {{ .Executable }} install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --pod-cidr 10.0.0.0/16 --service-cidr 10.1.0.0/16 \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+or (with out-of-band peering for restricted networks)
+  $ {{ .Executable }} install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-id my-rke2-cluster \
+      --cluster-labels region=us-west,environment=production
+`
+}
+
+// RegisterFlags registers the flags for the given provider.
+func (o *Options) RegisterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.APIServer, "api-server-url", "", "The Kubernetes API Server URL (defaults to the one specified in the kubeconfig)")
+	cmd.Flags().StringVar(&o.PodCIDR, "pod-cidr", "10.42.0.0/16", "The Pod CIDR of the cluster")
+	cmd.Flags().StringVar(&o.ServiceCIDR, "service-cidr", "10.43.0.0/16", "The Service CIDR of the cluster")
+}
+
+// Initialize performs the initialization tasks to retrieve the provider-specific parameters.
+func (o *Options) Initialize(_ context.Context) error {
+	// RKE2 API server typically runs on port 9345 and may use localhost addresses.
+	// Disable API server sanity checks to support these scenarios.
+	o.DisableAPIServerSanityChecks = true
+	return nil
+}
+
+// Values returns the customized provider-specifc values file parameters.
+func (o *Options) Values() map[string]interface{} {
+	return map[string]interface{}{
+		"networking": map[string]interface{}{
+			"fabric": map[string]interface{}{
+				"config": map[string]interface{}{
+					// RKE2 uses nftables by default, but monitoring can cause issues
+					// in some environments, similar to K3s
+					"nftablesMonitor": false,
+				},
+			},
+		},
+	}
+}

--- a/pkg/utils/foreigncluster/getters.go
+++ b/pkg/utils/foreigncluster/getters.go
@@ -31,11 +31,33 @@ import (
 )
 
 // GetForeignClusterByID returns a ForeignCluster CR retrieving it by its clusterID.
+//
+// This function implements a three-tier fallback lookup strategy to support both
+// standard label-based peering and out-of-band (manual) peering scenarios:
+//
+//  1. Label-based lookup (O(1) with index): Searches for ForeignClusters with the
+//     liqo.io/remote-cluster-id label matching the clusterID. This is the standard
+//     path used by liqoctl peer and is highly efficient.
+//
+//  2. Name-based lookup (O(1)): Fallback for out-of-band peering where ForeignCluster
+//     resources are created manually (e.g., via GitOps, kubectl apply) with name == clusterID.
+//     Common in RKE2 deployments and restricted network environments.
+//
+//  3. Exhaustive search (O(n)): Final fallback that iterates through ALL ForeignClusters
+//     to find one with spec.ClusterID matching the requested ID. This is expensive and
+//     should rarely be triggered in production.
+//
+// Performance considerations:
+//   - In clusters with many ForeignClusters (>100), the exhaustive search can impact
+//     API server performance. Consider adding liqo.io/remote-cluster-id labels to
+//     manually-created ForeignClusters to avoid this fallback.
+//   - The function logs when fallback #2 or #3 is used to aid in debugging and
+//     identifying misconfigured resources.
 func GetForeignClusterByID(ctx context.Context, cl client.Client, clusterID liqov1beta1.ClusterID) (*liqov1beta1.ForeignCluster, error) {
+	// Fallback #1: Label-based lookup (most efficient, O(1) with index)
 	lSelector := labels.SelectorFromSet(labels.Set{
 		consts.RemoteClusterID: string(clusterID),
 	})
-	// get the foreign cluster by clusterID label
 	foreignClusterList := liqov1beta1.ForeignClusterList{}
 	if err := cl.List(ctx, &foreignClusterList, &client.ListOptions{
 		LabelSelector: lSelector,
@@ -43,7 +65,45 @@ func GetForeignClusterByID(ctx context.Context, cl client.Client, clusterID liqo
 		return nil, err
 	}
 
-	return getForeignCluster(&foreignClusterList, clusterID)
+	// If found by label, return immediately (fast path)
+	if len(foreignClusterList.Items) > 0 {
+		klog.V(4).Infof("Found ForeignCluster %s by label lookup (fast path)", clusterID)
+		return getForeignCluster(&foreignClusterList, clusterID)
+	}
+
+	// Fallback #2: Name-based lookup for out-of-band peering (O(1))
+	// This supports manually-created ForeignCluster resources where name == clusterID
+	klog.V(4).Infof("Label lookup failed for ForeignCluster %s, trying name-based lookup (out-of-band peering)", clusterID)
+	fc := &liqov1beta1.ForeignCluster{}
+	err := cl.Get(ctx, client.ObjectKey{Name: string(clusterID)}, fc)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			// Fallback #3: Exhaustive search through all ForeignClusters (O(n))
+			// WARNING: This is expensive and can impact performance in large clusters
+			klog.Warningf("Name-based lookup failed for ForeignCluster %s, "+
+				"performing exhaustive search across all ForeignClusters (expensive operation)", clusterID)
+			allFCs := &liqov1beta1.ForeignClusterList{}
+			if listErr := cl.List(ctx, allFCs); listErr == nil {
+				for i := range allFCs.Items {
+					if allFCs.Items[i].Spec.ClusterID == clusterID {
+						klog.Warningf("Found ForeignCluster %s via exhaustive search. Consider adding the %s label to this resource for better performance",
+							clusterID, consts.RemoteClusterID)
+						return &allFCs.Items[i], nil
+					}
+				}
+			}
+		}
+		return nil, kerrors.NewNotFound(liqov1beta1.ForeignClusterGroupResource, fmt.Sprintf("foreign cluster with ID %s", clusterID))
+	}
+
+	// Validate that the ForeignCluster found by name has the correct spec.ClusterID
+	if fc.Spec.ClusterID != "" && fc.Spec.ClusterID != clusterID {
+		klog.Warningf("ForeignCluster %s found by name but spec.ClusterID mismatch (expected: %s, got: %s)", fc.Name, clusterID, fc.Spec.ClusterID)
+		return nil, kerrors.NewNotFound(liqov1beta1.ForeignClusterGroupResource, fmt.Sprintf("foreign cluster with ID %s", clusterID))
+	}
+
+	klog.V(4).Infof("Found ForeignCluster %s by name-based lookup (out-of-band peering)", clusterID)
+	return fc, nil
 }
 
 // GetForeignClusterByIDWithDynamicClient returns a ForeignCluster CR retrieving it by its clusterID, using the dynamic interface.
@@ -85,7 +145,7 @@ func GetOlderForeignCluster(
 	var olderTime *metav1.Time
 	for i := range foreignClusterList.Items {
 		fc := &foreignClusterList.Items[i]
-		if olderTime.IsZero() || fc.CreationTimestamp.Before(olderTime) {
+		if olderTime == nil || fc.CreationTimestamp.Before(olderTime) {
 			olderTime = &fc.CreationTimestamp
 			foreignCluster = fc
 		}

--- a/pkg/utils/foreigncluster/getters_suite_test.go
+++ b/pkg/utils/foreigncluster/getters_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foreigncluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestForeignCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ForeignCluster Utils Suite")
+}

--- a/pkg/utils/foreigncluster/getters_test.go
+++ b/pkg/utils/foreigncluster/getters_test.go
@@ -1,0 +1,280 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foreigncluster_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/foreigncluster"
+)
+
+var _ = Describe("GetForeignClusterByID function", func() {
+	const (
+		testClusterID1 = liqov1beta1.ClusterID("test-cluster-1")
+		testClusterID2 = liqov1beta1.ClusterID("test-cluster-2")
+		testClusterID3 = liqov1beta1.ClusterID("test-cluster-3")
+		testClusterID4 = liqov1beta1.ClusterID("test-cluster-4")
+		nonExistentID  = liqov1beta1.ClusterID("non-existent-cluster")
+	)
+
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+		cl     client.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(liqov1beta1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Context("Fallback #1: Label-based lookup (fast path)", func() {
+		BeforeEach(func() {
+			// Create a ForeignCluster with the standard label
+			fc := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-with-label",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc).Build()
+		})
+
+		It("should find ForeignCluster by label", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Spec.ClusterID).To(Equal(testClusterID1))
+			Expect(fc.Name).To(Equal("fc-with-label"))
+		})
+
+		It("should return not found for non-existent cluster", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, nonExistentID)
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(fc).To(BeNil())
+		})
+	})
+
+	Context("Fallback #2: Name-based lookup (out-of-band peering)", func() {
+		BeforeEach(func() {
+			// Create a ForeignCluster without the label, but with name == clusterID
+			// This simulates manual/out-of-band creation
+			fc := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID2), // Name matches clusterID
+					// Note: No liqo.io/remote-cluster-id label
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID2,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc).Build()
+		})
+
+		It("should find ForeignCluster by name when label is missing", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Spec.ClusterID).To(Equal(testClusterID2))
+			Expect(fc.Name).To(Equal(string(testClusterID2)))
+		})
+
+		It("should validate spec.ClusterID matches requested ID", func() {
+			// Create a ForeignCluster where name matches but spec.ClusterID doesn't
+			fcMismatch := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID3),
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "different-cluster-id", // Mismatch!
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fcMismatch).Build()
+
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID3)
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(fc).To(BeNil())
+		})
+	})
+
+	Context("Fallback #3: Exhaustive search (expensive operation)", func() {
+		BeforeEach(func() {
+			// Create multiple ForeignClusters, none with the correct label or name
+			// Only one has the matching spec.ClusterID
+			fc1 := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "random-name-1",
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "some-other-cluster",
+				},
+			}
+			fc2 := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "random-name-2",
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID4, // This is the one we're looking for
+				},
+			}
+			fc3 := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "random-name-3",
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "yet-another-cluster",
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc1, fc2, fc3).Build()
+		})
+
+		It("should find ForeignCluster via exhaustive search when label and name lookups fail", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Spec.ClusterID).To(Equal(testClusterID4))
+			Expect(fc.Name).To(Equal("random-name-2"))
+		})
+
+		It("should return not found when exhaustive search finds nothing", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, nonExistentID)
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(fc).To(BeNil())
+		})
+	})
+
+	Context("Multiple ForeignClusters with same label", func() {
+		var (
+			fc1 *liqov1beta1.ForeignCluster
+			fc2 *liqov1beta1.ForeignCluster
+		)
+
+		BeforeEach(func() {
+			// Create two ForeignClusters with the same label
+			// The function should return the older one based on creationTimestamp
+			fc1 = &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-older",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+					CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-24 * time.Hour)}, // 1 day ago
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			fc2 = &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-newer",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+					CreationTimestamp: metav1.Now(), // Now
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc1, fc2).Build()
+		})
+
+		It("should return the older ForeignCluster when multiple exist", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Name).To(Equal("fc-older"))
+		})
+	})
+
+	Context("Edge cases", func() {
+		It("should handle empty clusterID gracefully", func() {
+			cl = fake.NewClientBuilder().WithScheme(scheme).Build()
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, "")
+			Expect(err).To(HaveOccurred())
+			Expect(fc).To(BeNil())
+		})
+
+		It("should handle ForeignCluster with empty spec.ClusterID in name-based lookup", func() {
+			// ForeignCluster with name matching but empty spec.ClusterID should still be found
+			fcEmpty := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID2),
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "", // Empty
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fcEmpty).Build()
+
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Name).To(Equal(string(testClusterID2)))
+		})
+	})
+
+	Context("Combination scenarios (testing fallback chain)", func() {
+		It("should prefer label-based lookup over name-based when both exist", func() {
+			// Create two ForeignClusters: one with label, one matching by name
+			fcWithLabel := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-with-label",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			fcByName := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID1), // Name matches
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fcWithLabel, fcByName).Build()
+
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			// Should return the one found by label (fast path)
+			Expect(fc.Name).To(Equal("fc-with-label"))
+		})
+	})
+})


### PR DESCRIPTION
Adds `liqoctl install rke2` provider for RKE2 and extends `GetForeignClusterByID` to support out-of-band peering scenarios where ForeignCluster resources need to be created manually.

#### RKE2 Install Provider

Defaults: pod CIDR `10.42.0.0/16`, service CIDR `10.43.0.0/16`. Disables API server sanity checks (RKE2 uses port 9345) and nftables monitoring (prevents conflicts with RKE2's iptables rules).

#### Integrate with three-tier ForeignCluster Lookup 
- While this is what I've come up with, I'll be the first to admit this feels a bit wonky architecturally; there is probably a more clever-er way to do this 👀 

Extends `GetForeignClusterByID` with fallback for clusters where ForeignCluster resources lack the `liqo.io/remote-cluster-id` label:

1. **Label-based** — O(1) with index, standard `liqoctl peer` path
2. **Name-based** — O(1) by convention (`name == clusterID`), for GitOps/manual creation
3. **Exhaustive** — O(n) final fallback with performance warnings

Fixes liqotech/liqo#1092
Supersedes liqotech/liqo#3139