### PR TITLE
test: combined Cilium eBPF + RKE2 regression test (with RBAC + key fix)

### DIFF
--- a/.github/workflows/build-fabric.yml
+++ b/.github/workflows/build-fabric.yml
@@ -1,0 +1,83 @@
+name: Build Fabric Image
+on:
+  push:
+    branches:
+      - 'test/**'
+      - 'feat/**'
+      - 'fix/**'
+    paths:
+      - 'cmd/fabric/**'
+      - 'pkg/fabric/**'
+      - 'build/liqo/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/build-fabric.yml'
+  workflow_dispatch:
+
+env:
+  DOCKER_REGISTRY: ghcr.io
+  DOCKER_ORGANIZATION: jesssullivan
+
+jobs:
+  build-fabric:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image tag
+        id: tag
+        run: |
+          # Use branch-name-short-sha format
+          BRANCH="${GITHUB_REF_NAME}"
+          # Sanitize branch name for docker tag (replace / with -)
+          BRANCH_SAFE=$(echo "$BRANCH" | sed 's|/|-|g')
+          SHA_SHORT=$(echo "$GITHUB_SHA" | head -c 8)
+          echo "tag=${BRANCH_SAFE}-${SHA_SHORT}" >> $GITHUB_OUTPUT
+          echo "branch=${BRANCH_SAFE}" >> $GITHUB_OUTPUT
+
+      - name: Build and push fabric image
+        env:
+          DOCKER_TAG: ${{ steps.tag.outputs.tag }}
+          DOCKER_PUSH: "true"
+          ARCHS: linux/amd64
+        run: |
+          chmod +x ./build/liqo/build.sh
+          ./build/liqo/build.sh ./cmd/fabric
+
+      - name: Summary
+        run: |
+          echo "## Fabric Image Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`ghcr.io/jesssullivan/fabric-ci:${{ steps.tag.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Deploy to cluster" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "helm upgrade liqo liqo --repo https://helm.liqo.io \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --namespace liqo \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --reuse-values \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --set networking.fabric.image.name=ghcr.io/jesssullivan/fabric-ci \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --set networking.fabric.image.version=${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -33,6 +33,7 @@ RUN if [ "$COMPONENT" = "wireguard" ]; then \
 COPY ./bin/${TARGETARCH}/${COMPONENT}_linux_${TARGETARCH} /usr/bin/${COMPONENT}
 RUN chmod +x /usr/bin/${COMPONENT}
 RUN ln -s /usr/bin/${COMPONENT} /usr/bin/liqo-component
+RUN ln -s /usr/bin/${COMPONENT} /usr/bin/liqo-${COMPONENT}
 
 WORKDIR /workspace
 

--- a/cmd/fabric/main.go
+++ b/cmd/fabric/main.go
@@ -37,6 +37,7 @@ import (
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/fabric"
+	"github.com/liqotech/liqo/pkg/fabric/cilium"
 	sourcedetector "github.com/liqotech/liqo/pkg/fabric/source-detector"
 	"github.com/liqotech/liqo/pkg/firewall"
 	"github.com/liqotech/liqo/pkg/gateway"
@@ -149,6 +150,46 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up readyz probe: %w", err)
+	}
+
+	// Detect Cilium CNI configuration for eBPF host routing compatibility.
+	// Uses a non-cached client because the manager cache hasn't started yet.
+	directClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("unable to create direct client for Cilium detection: %w", err)
+	}
+	ciliumConfig, err := cilium.DetectAndLog(cmd.Context(), directClient)
+	if err != nil {
+		klog.Warningf("Failed to detect Cilium configuration: %v", err)
+		ciliumConfig = nil
+	}
+
+	// Setup Cilium VTEP controller if eBPF host routing requires it.
+	if ciliumConfig != nil && ciliumConfig.IsBPFHostRouting() {
+		vtepReconciler := cilium.NewVTEPReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			mgr.GetEventRecorderFor("cilium-vtep-controller"),
+			ciliumConfig,
+		)
+		if err := vtepReconciler.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to setup Cilium VTEP reconciler: %w", err)
+		}
+
+		ipcacheReconciler, err := cilium.NewIPCacheReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			mgr.GetEventRecorderFor("cilium-ipcache-controller"),
+			ciliumConfig,
+			cfg,
+			options.NodeName,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to create Cilium IPCache reconciler: %w", err)
+		}
+		if err := ipcacheReconciler.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to setup Cilium IPCache reconciler: %w", err)
+		}
 	}
 
 	gwr, err := sourcedetector.NewGatewayReconciler(

--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kind"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kubeadm"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/openshift"
+	"github.com/liqotech/liqo/pkg/liqoctl/install/rke2"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/utils"
 	"github.com/liqotech/liqo/pkg/liqoctl/version"
@@ -188,6 +189,7 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, kind.New))
 	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, kubeadm.New))
 	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, openshift.New))
+	utils.AddCommand(cmd, newInstallProviderCommand(ctx, options.CommonOptions, rke2.New))
 
 	return cmd
 }

--- a/deployments/liqo/files/liqo-fabric-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-fabric-ClusterRole.yaml
@@ -20,8 +20,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.liqo.io
   resources:
+  - configurations
   - firewallconfigurations
   - firewallconfigurations/status
   - genevetunnels

--- a/deployments/liqo/files/liqo-fabric-Role.yaml
+++ b/deployments/liqo/files/liqo-fabric-Role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: liqo-fabric
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deployments/liqo/templates/liqo-fabric-rbac.yaml
+++ b/deployments/liqo/templates/liqo-fabric-rbac.yaml
@@ -41,5 +41,30 @@ metadata:
   verbs:
   - use
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "liqo.prefixedName" $fabricConfig }}
+  namespace: kube-system
+  labels:
+    {{- include "liqo.labels" $fabricConfig | nindent 4 }}
+{{ .Files.Get (include "liqo.role-filename" (dict "prefix" ( include "liqo.prefixedName" $fabricConfig))) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "liqo.prefixedName" $fabricConfig }}
+  namespace: kube-system
+  labels:
+    {{- include "liqo.labels" $fabricConfig | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "liqo.prefixedName" $fabricConfig }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "liqo.prefixedName" $fabricConfig }}
+    namespace: {{ .Release.Namespace }}
 
 {{- end }}

--- a/docs/usage/liqoctl/liqoctl_install.md
+++ b/docs/usage/liqoctl/liqoctl_install.md
@@ -1355,3 +1355,181 @@ liqoctl install openshift [flags]
 
 >The version of Liqo to be installed, among releases and commit SHAs. Defaults to the liqoctl version **(default "unknown")**
 
+## liqoctl install rke2
+
+Install Liqo in the selected rke2 cluster
+
+### Synopsis
+
+Install/upgrade Liqo in the selected rke2 cluster.
+
+This command wraps the Helm command to install/upgrade Liqo in the selected
+rke2 cluster, automatically retrieving most parameters based on the cluster
+configuration.
+
+Please, refer to the help of the root *liqoctl install* command for additional
+information and examples concerning its behavior and the common flags.
+
+
+
+```
+liqoctl install rke2 [flags]
+```
+
+### Examples
+
+
+```bash
+  $ liqoctl install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+```
+
+or
+
+```bash
+  $ liqoctl install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --pod-cidr 10.0.0.0/16 --service-cidr 10.1.0.0/16 \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+```
+
+or (with out-of-band peering for restricted networks)
+
+```bash
+  $ liqoctl install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-id my-rke2-cluster \
+      --cluster-labels region=us-west,environment=production
+```
+
+
+
+
+
+
+
+
+### Options
+`--api-server-url` _string_:
+
+>The Kubernetes API Server URL (defaults to the one specified in the kubeconfig)
+
+`--pod-cidr` _string_:
+
+>The Pod CIDR of the cluster **(default "10.42.0.0/16")**
+
+`--service-cidr` _string_:
+
+>The Service CIDR of the cluster **(default "10.43.0.0/16")**
+
+
+### Global options
+
+`--cluster` _string_:
+
+>The name of the kubeconfig cluster to use
+
+`--cluster-id` _clusterID_:
+
+>The id identifying the cluster in Liqo
+
+`--cluster-labels` _stringMap_:
+
+>The set of labels (i.e., key/value pairs, separated by comma) identifying the current cluster, and propagated to the virtual nodes
+
+`--context` _string_:
+
+>The name of the kubeconfig context to use
+
+`--disable-api-server-sanity-check`
+
+>Disable the sanity checks concerning the retrieved Kubernetes API server URL (default false)
+
+`--disable-kernel-version-check`
+
+>Disable the check of the minimum kernel version required to run the wireguard interface (default false)
+
+`--disable-telemetry`
+
+>Disable the anonymous and aggregated Liqo telemetry collection (default false)
+
+`--dry-run`
+
+>Simulate the installation process (default false)
+
+`--dump-values-path` _string_:
+
+>The path where the generated values file is saved (only in case --only-output-values is set). Default: './values.yaml'
+
+`--enable-metrics`
+
+>Enable metrics exposition through prometheus (default false)
+
+`--global-annotations` _stringToString_:
+
+>Global annotations to be added to all created resources (key=value)
+
+`--global-labels` _stringToString_:
+
+>Global labels to be added to all created resources (key=value)
+
+`--kubeconfig` _string_:
+
+>Path to the kubeconfig file to use for CLI requests
+
+`--local-chart-path` _string_:
+
+>The local path used to retrieve the Helm chart, instead of the upstream one
+
+`-n`, `--namespace` _string_:
+
+>The namespace where Liqo is installed in **(default "liqo")**
+
+`--only-output-values`
+
+>Generate the pre-configured values file for further customization, instead of installing Liqo (default false)
+
+`--repo-url` _string_:
+
+>The URL of the git repository used to retrieve the Helm chart, if a non released version is specified **(default "https://github.com/liqotech/liqo")**
+
+`--reserved-subnets` _cidrList_:
+
+>The private CIDRs to be excluded, as already in use (e.g., the subnet of the cluster nodes); PodCIDR and ServiceCIDR shall not be included.
+
+`--set` _stringArray_:
+
+>Set additional values on the command line (can specify multiple times or separate values with commas: key1=val1,key2=val2)
+
+`--set-string` _stringArray_:
+
+>Set additional string values on the command line (can specify multiple times or separate values with commas: key1=val1,key2=val2)
+
+`--skip-confirm`
+
+>Skip the confirmation prompt (suggested for automation)
+
+`--skip-validation`
+
+>Skip the validation of the arguments (PodCIDR, ServiceCIDR). This is useful when you are sure of what you are doing and the amount of pods and services in your cluster is very large (default false)
+
+`--timeout` _duration_:
+
+>The timeout for the completion of the installation process **(default 10m0s)**
+
+`--user` _string_:
+
+>The name of the kubeconfig user to use
+
+`--values` _stringArray_:
+
+>Specify values in a YAML file or a URL (can specify multiple)
+
+`-v`, `--verbose`
+
+>Enable verbose logs (default false)
+
+`--version` _string_:
+
+>The version of Liqo to be installed, among releases and commit SHAs. Defaults to the liqoctl version **(default "unknown")**
+

--- a/pkg/fabric/cilium/detect.go
+++ b/pkg/fabric/cilium/detect.go
@@ -1,0 +1,218 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// HostRoutingModeBPF indicates Cilium uses eBPF host routing.
+	HostRoutingModeBPF = "BPF"
+	// HostRoutingModeLegacy indicates Cilium uses legacy kernel routing.
+	HostRoutingModeLegacy = "Legacy"
+	// boolTrue is the string representation of true for ConfigMap parsing.
+	boolTrue = "true"
+)
+
+// Config holds the detected Cilium configuration.
+type Config struct {
+	// Detected indicates whether Cilium was detected in the cluster.
+	Detected bool
+	// HostRoutingMode is the host routing mode ("BPF" or "Legacy").
+	HostRoutingMode string
+	// KubeProxyReplacement indicates if kube-proxy replacement is enabled.
+	KubeProxyReplacement bool
+	// BPFMasqueradeEnabled indicates if BPF masquerading is enabled.
+	BPFMasqueradeEnabled bool
+	// LRPSupported indicates if CiliumLocalRedirectPolicy CRD is available.
+	LRPSupported bool
+	// LegacyHostRoutingEnabled indicates if bpf.hostLegacyRouting=true is set.
+	LegacyHostRoutingEnabled bool
+	// VTEPEnabled indicates if VTEP integration is already enabled.
+	VTEPEnabled bool
+}
+
+// IsBPFHostRouting returns true if Cilium is using BPF host routing,
+// which bypasses kernel routing tables and requires special integration for Liqo.
+func (c *Config) IsBPFHostRouting() bool {
+	return c.Detected && c.HostRoutingMode == HostRoutingModeBPF
+}
+
+// NeedsLRP returns true if this Cilium configuration requires
+// CiliumLocalRedirectPolicy for Liqo cross-cluster traffic.
+func (c *Config) NeedsLRP() bool {
+	return c.IsBPFHostRouting() && c.LRPSupported
+}
+
+// NeedsVTEP returns true if this Cilium configuration requires VTEP integration
+// for Liqo cross-cluster traffic.
+func (c *Config) NeedsVTEP() bool {
+	return c.IsBPFHostRouting() && !c.LegacyHostRoutingEnabled && !c.VTEPEnabled
+}
+
+// IsLegacyHostRoutingEnabled returns true if Cilium has legacy host routing
+// fallback enabled (bpf.hostLegacyRouting=true), which allows kernel routes to work.
+func (c *Config) IsLegacyHostRoutingEnabled() bool {
+	return c.LegacyHostRoutingEnabled
+}
+
+const (
+	// CiliumConfigMapName is the name of the Cilium ConfigMap.
+	CiliumConfigMapName = "cilium-config"
+	// CiliumNamespace is the namespace where Cilium is typically installed.
+	CiliumNamespace = "kube-system"
+	// CiliumDaemonSetName is the name of the Cilium DaemonSet.
+	CiliumDaemonSetName = "cilium"
+)
+
+// DetectConfig detects Cilium configuration from the cluster.
+// This function reads the cilium-config ConfigMap and determines
+// whether Liqo needs to use CiliumLocalRedirectPolicy for routing.
+func DetectConfig(ctx context.Context, cl client.Client) (*Config, error) {
+	config := &Config{
+		Detected: false,
+	}
+
+	// Try to read the cilium-config ConfigMap.
+	cm := &corev1.ConfigMap{}
+	err := cl.Get(ctx, types.NamespacedName{
+		Name:      CiliumConfigMapName,
+		Namespace: CiliumNamespace,
+	}, cm)
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Info("Cilium ConfigMap not found, Cilium not detected")
+			return config, nil
+		}
+		return nil, fmt.Errorf("failed to get cilium-config ConfigMap: %w", err)
+	}
+
+	// Cilium detected.
+	config.Detected = true
+	klog.V(2).Info("Cilium CNI detected in cluster")
+
+	// Parse configuration values.
+	if hostRouting, ok := cm.Data["bpf-lb-sock-hostns-only"]; ok {
+		// This is a proxy for eBPF mode - not direct but indicative.
+		klog.V(4).Infof("Cilium bpf-lb-sock-hostns-only: %s", hostRouting)
+	}
+
+	// Check for enable-bpf-masquerade.
+	if bpfMasq, ok := cm.Data["enable-bpf-masquerade"]; ok {
+		config.BPFMasqueradeEnabled = strings.EqualFold(bpfMasq, boolTrue)
+	}
+
+	// Check for kube-proxy-replacement.
+	if kpr, ok := cm.Data["kube-proxy-replacement"]; ok {
+		config.KubeProxyReplacement = strings.EqualFold(kpr, boolTrue) ||
+			strings.EqualFold(kpr, "strict") ||
+			strings.EqualFold(kpr, "partial")
+	}
+
+	// Check routing mode - the key indicator for eBPF host routing.
+	// In Cilium, routing-mode can be "native" (eBPF) or "tunnel".
+	if routingMode, ok := cm.Data["routing-mode"]; ok {
+		if routingMode == "native" {
+			config.HostRoutingMode = HostRoutingModeBPF
+		} else {
+			config.HostRoutingMode = HostRoutingModeLegacy
+		}
+	} else {
+		// Default assumption: if Cilium is present with kube-proxy replacement,
+		// it's likely using BPF host routing.
+		if config.KubeProxyReplacement || config.BPFMasqueradeEnabled {
+			config.HostRoutingMode = HostRoutingModeBPF
+		} else {
+			config.HostRoutingMode = HostRoutingModeLegacy
+		}
+	}
+
+	// Check for legacy host routing fallback (bpf.hostLegacyRouting=true).
+	if legacyRouting, ok := cm.Data["bpf-host-legacy-routing"]; ok {
+		config.LegacyHostRoutingEnabled = strings.EqualFold(legacyRouting, boolTrue)
+	}
+
+	// Check for VTEP integration.
+	if vtepEnabled, ok := cm.Data["enable-vtep"]; ok {
+		config.VTEPEnabled = strings.EqualFold(vtepEnabled, boolTrue)
+	}
+
+	// Check if CiliumLocalRedirectPolicy CRD is available.
+	config.LRPSupported = checkLRPSupport(ctx, cl)
+
+	klog.Infof(
+		"Cilium detected: HostRouting=%s, KubeProxyReplacement=%v, LegacyRouting=%v, VTEP=%v, LRPSupported=%v",
+		config.HostRoutingMode, config.KubeProxyReplacement, config.LegacyHostRoutingEnabled,
+		config.VTEPEnabled, config.LRPSupported)
+
+	return config, nil
+}
+
+// checkLRPSupport checks if the CiliumLocalRedirectPolicy CRD is available.
+func checkLRPSupport(_ context.Context, _ client.Client) bool {
+	// We check by trying to list CiliumLocalRedirectPolicy resources.
+	// If the CRD doesn't exist, this will fail.
+	// Using unstructured client to avoid import cycles.
+
+	// For now, we assume LRP is supported if Cilium is detected.
+	// A more robust check would query the API server for the CRD.
+	// This can be enhanced later with proper CRD detection.
+	klog.V(4).Info("Assuming CiliumLocalRedirectPolicy CRD is available")
+	return true
+}
+
+// DetectAndLog detects Cilium configuration and logs the result.
+func DetectAndLog(ctx context.Context, cl client.Client) (*Config, error) {
+	config, err := DetectConfig(ctx, cl)
+	if err != nil {
+		klog.Errorf("Failed to detect Cilium configuration: %v", err)
+		return nil, err
+	}
+
+	switch {
+	case !config.Detected:
+		klog.V(2).Info("Cilium not detected - using standard Liqo routing")
+	case !config.IsBPFHostRouting():
+		klog.Info("Cilium detected with legacy routing - standard Liqo routing will be used")
+	default:
+		switch {
+		case config.LegacyHostRoutingEnabled:
+			klog.Info("Cilium eBPF host routing detected with legacy fallback - standard Liqo routing will work")
+		case config.VTEPEnabled:
+			klog.Info("Cilium eBPF host routing detected with VTEP enabled - Liqo VTEP controller will manage routing")
+		case config.NeedsVTEP():
+			klog.Warning("Cilium eBPF host routing detected without legacy fallback or VTEP. " +
+				"Cross-cluster routing may fail. Options: " +
+				"1) Set bpf.hostLegacyRouting=true in Cilium, or " +
+				"2) Liqo will configure VTEP integration automatically")
+		}
+
+		if config.NeedsLRP() {
+			klog.Info("CiliumLocalRedirectPolicy support detected for endpoint-level routing")
+		}
+	}
+
+	return config, nil
+}

--- a/pkg/fabric/cilium/detect.go
+++ b/pkg/fabric/cilium/detect.go
@@ -149,8 +149,9 @@ func DetectConfig(ctx context.Context, cl client.Client) (*Config, error) {
 		}
 	}
 
-	// Check for legacy host routing fallback (bpf.hostLegacyRouting=true).
-	if legacyRouting, ok := cm.Data["bpf-host-legacy-routing"]; ok {
+	// Check for legacy host routing fallback.
+	// Cilium ConfigMap uses "enable-host-legacy-routing" (not the Helm value name "bpf-host-legacy-routing").
+	if legacyRouting, ok := cm.Data["enable-host-legacy-routing"]; ok {
 		config.LegacyHostRoutingEnabled = strings.EqualFold(legacyRouting, boolTrue)
 	}
 

--- a/pkg/fabric/cilium/detect_test.go
+++ b/pkg/fabric/cilium/detect_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Cilium Detection", func() {
 					"routing-mode":            "native",
 					"kube-proxy-replacement":  "true",
 					"enable-bpf-masquerade":   "true",
-					"bpf-host-legacy-routing": "false",
+					"enable-host-legacy-routing": "false",
 					"enable-vtep":             "false",
 				})
 			})
@@ -181,7 +181,7 @@ var _ = Describe("Cilium Detection", func() {
 			BeforeEach(func() {
 				createCiliumConfigMap(ctx, k8sClient, map[string]string{
 					"routing-mode":            "native",
-					"bpf-host-legacy-routing": "true",
+					"enable-host-legacy-routing": "true",
 				})
 			})
 

--- a/pkg/fabric/cilium/detect_test.go
+++ b/pkg/fabric/cilium/detect_test.go
@@ -1,0 +1,254 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cilium Detection", func() {
+	Context("Config methods", func() {
+		Describe("IsBPFHostRouting", func() {
+			It("should return true when Cilium is detected with BPF host routing", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeBPF,
+				}
+				Expect(config.IsBPFHostRouting()).To(BeTrue())
+			})
+
+			It("should return false when Cilium is not detected", func() {
+				config := &Config{
+					Detected:        false,
+					HostRoutingMode: HostRoutingModeBPF,
+				}
+				Expect(config.IsBPFHostRouting()).To(BeFalse())
+			})
+
+			It("should return false when using legacy routing", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeLegacy,
+				}
+				Expect(config.IsBPFHostRouting()).To(BeFalse())
+			})
+		})
+
+		Describe("NeedsLRP", func() {
+			It("should return true when BPF host routing and LRP supported", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeBPF,
+					LRPSupported:    true,
+				}
+				Expect(config.NeedsLRP()).To(BeTrue())
+			})
+
+			It("should return false when LRP not supported", func() {
+				config := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeBPF,
+					LRPSupported:    false,
+				}
+				Expect(config.NeedsLRP()).To(BeFalse())
+			})
+		})
+
+		Describe("NeedsVTEP", func() {
+			It("should return true when BPF routing without legacy fallback or VTEP", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "BPF",
+					LegacyHostRoutingEnabled: false,
+					VTEPEnabled:              false,
+				}
+				Expect(config.NeedsVTEP()).To(BeTrue())
+			})
+
+			It("should return false when legacy host routing is enabled", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "BPF",
+					LegacyHostRoutingEnabled: true,
+					VTEPEnabled:              false,
+				}
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+
+			It("should return false when VTEP is already enabled", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "BPF",
+					LegacyHostRoutingEnabled: false,
+					VTEPEnabled:              true,
+				}
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+
+			It("should return false when using legacy routing mode", func() {
+				config := &Config{
+					Detected:                 true,
+					HostRoutingMode:          "Legacy",
+					LegacyHostRoutingEnabled: false,
+					VTEPEnabled:              false,
+				}
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+		})
+
+		Describe("IsLegacyHostRoutingEnabled", func() {
+			It("should return true when legacy host routing is enabled", func() {
+				config := &Config{
+					LegacyHostRoutingEnabled: true,
+				}
+				Expect(config.IsLegacyHostRoutingEnabled()).To(BeTrue())
+			})
+
+			It("should return false when legacy host routing is disabled", func() {
+				config := &Config{
+					LegacyHostRoutingEnabled: false,
+				}
+				Expect(config.IsLegacyHostRoutingEnabled()).To(BeFalse())
+			})
+		})
+	})
+
+	Context("DetectConfig", func() {
+		AfterEach(func() {
+			deleteCiliumConfigMap(ctx, k8sClient)
+		})
+
+		When("cilium-config ConfigMap does not exist", func() {
+			It("should return config with Detected=false", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeFalse())
+			})
+		})
+
+		When("cilium-config ConfigMap exists with native routing", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode":            "native",
+					"kube-proxy-replacement":  "true",
+					"enable-bpf-masquerade":   "true",
+					"bpf-host-legacy-routing": "false",
+					"enable-vtep":             "false",
+				})
+			})
+
+			It("should detect Cilium with BPF host routing", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.HostRoutingMode).To(Equal(HostRoutingModeBPF))
+				Expect(config.KubeProxyReplacement).To(BeTrue())
+				Expect(config.BPFMasqueradeEnabled).To(BeTrue())
+				Expect(config.LegacyHostRoutingEnabled).To(BeFalse())
+				Expect(config.VTEPEnabled).To(BeFalse())
+			})
+		})
+
+		When("cilium-config ConfigMap exists with tunnel routing", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode": "tunnel",
+				})
+			})
+
+			It("should detect Cilium with legacy host routing", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.HostRoutingMode).To(Equal(HostRoutingModeLegacy))
+			})
+		})
+
+		When("cilium-config has legacy host routing enabled", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode":            "native",
+					"bpf-host-legacy-routing": "true",
+				})
+			})
+
+			It("should detect legacy host routing fallback", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.LegacyHostRoutingEnabled).To(BeTrue())
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+		})
+
+		When("cilium-config has VTEP enabled", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode": "native",
+					"enable-vtep":  "true",
+				})
+			})
+
+			It("should detect VTEP is enabled", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.VTEPEnabled).To(BeTrue())
+				Expect(config.NeedsVTEP()).To(BeFalse())
+			})
+		})
+
+		When("cilium-config implies BPF from kube-proxy replacement", func() {
+			BeforeEach(func() {
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"kube-proxy-replacement": "strict",
+				})
+			})
+
+			It("should infer BPF host routing", func() {
+				config, err := DetectConfig(ctx, k8sClient)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Detected).To(BeTrue())
+				Expect(config.HostRoutingMode).To(Equal(HostRoutingModeBPF))
+				Expect(config.KubeProxyReplacement).To(BeTrue())
+			})
+		})
+	})
+
+	Context("DetectAndLog", func() {
+		AfterEach(func() {
+			deleteCiliumConfigMap(ctx, k8sClient)
+		})
+
+		It("should detect and log when Cilium is not present", func() {
+			config, err := DetectAndLog(ctx, k8sClient)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Detected).To(BeFalse())
+		})
+
+		It("should detect and log BPF host routing configuration", func() {
+			createCiliumConfigMap(ctx, k8sClient, map[string]string{
+				"routing-mode":           "native",
+				"kube-proxy-replacement": "true",
+			})
+
+			config, err := DetectAndLog(ctx, k8sClient)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Detected).To(BeTrue())
+			Expect(config.IsBPFHostRouting()).To(BeTrue())
+		})
+	})
+})

--- a/pkg/fabric/cilium/doc.go
+++ b/pkg/fabric/cilium/doc.go
@@ -1,0 +1,47 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cilium provides Cilium CNI integration for Liqo multi-cluster networking.
+//
+// # Problem
+//
+// Cilium with eBPF host routing (routing-mode: native) bypasses kernel routing
+// tables entirely. This breaks Liqo's network fabric, which relies on ip rules
+// and custom routing tables to direct cross-cluster traffic through WireGuard.
+//
+// # Solution
+//
+// Two integration strategies, auto-selected at startup:
+//
+//  1. VTEP Integration - Populates Cilium's VTEP configuration in the
+//     cilium-config ConfigMap with gateway pod endpoints, remote CIDRs,
+//     netmasks, and deterministic MAC addresses.
+//  2. IPCache Injection - Injects remote pod CIDRs into Cilium's ipcache
+//     via CiliumNode annotations.
+//
+// If bpf.hostLegacyRouting=true is set in Cilium, kernel routing works
+// normally and no Liqo-side changes are needed.
+//
+// CiliumLocalRedirectPolicy (LRP) was evaluated but does not support CIDR-based
+// matching, only single IPs. It cannot be used for cross-cluster pod CIDR routing.
+//
+// # Usage
+//
+// Automatically enabled when Cilium is detected (cilium-config ConfigMap exists)
+// with eBPF host routing. No manual configuration required.
+//
+// # References
+//
+//   - GitHub Issue: https://github.com/liqotech/liqo/issues/2166
+package cilium

--- a/pkg/fabric/cilium/ipcache_controller.go
+++ b/pkg/fabric/cilium/ipcache_controller.go
@@ -1,0 +1,358 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+const (
+	// IPCacheControllerFinalizer is the finalizer for ipcache cleanup.
+	IPCacheControllerFinalizer = "liqo.io/cilium-ipcache-controller"
+	// IPCacheControllerName is the controller name.
+	IPCacheControllerName = "cilium-ipcache-controller"
+	// LiqoRemoteCIDRAnnotationPrefix is the prefix for remote CIDR annotations.
+	LiqoRemoteCIDRAnnotationPrefix = "liqo.io/remote-cidr-"
+)
+
+// CiliumNodeGVR is the GroupVersionResource for CiliumNode.
+var CiliumNodeGVR = schema.GroupVersionResource{
+	Group:    "cilium.io",
+	Version:  "v2",
+	Resource: "ciliumnodes",
+}
+
+// RemoteCIDREntry represents a Liqo remote CIDR entry for ipcache injection.
+type RemoteCIDREntry struct {
+	// CIDR is the remote pod CIDR (e.g., "10.244.0.0/16").
+	CIDR string `json:"cidr"`
+	// TunnelEndpoint is the gateway pod IP that handles traffic for this CIDR.
+	TunnelEndpoint string `json:"tunnelEndpoint"`
+	// RemoteClusterID is the ID of the remote cluster.
+	RemoteClusterID string `json:"remoteClusterID"`
+	// Identity is the Cilium security identity (optional, defaults to world).
+	Identity uint32 `json:"identity,omitempty"`
+}
+
+// IPCacheReconciler manages Cilium ipcache entries for Liqo remote CIDRs.
+// When Cilium eBPF host routing is enabled, kernel routing tables are bypassed.
+// This controller injects remote pod CIDRs into Cilium's ipcache so that
+// eBPF can route cross-cluster traffic correctly.
+type IPCacheReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	EventsRecorder record.EventRecorder
+	Config         *Config
+	DynamicClient  dynamic.Interface
+	LocalNodeName  string
+}
+
+// NewIPCacheReconciler creates a new IPCacheReconciler.
+func NewIPCacheReconciler(
+	cl client.Client,
+	scheme *runtime.Scheme,
+	recorder record.EventRecorder,
+	ciliumConfig *Config,
+	cfg *rest.Config,
+	nodeName string,
+) (*IPCacheReconciler, error) {
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return &IPCacheReconciler{
+		Client:         cl,
+		Scheme:         scheme,
+		EventsRecorder: recorder,
+		Config:         ciliumConfig,
+		DynamicClient:  dynClient,
+		LocalNodeName:  nodeName,
+	}, nil
+}
+
+// +kubebuilder:rbac:groups=networking.liqo.io,resources=configurations,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=cilium.io,resources=ciliumnodes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile handles Configuration events and manages Cilium ipcache entries.
+func (r *IPCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(4).Infof("Reconciling Configuration %s for Cilium ipcache", req.NamespacedName)
+
+	// Skip if Cilium doesn't need ipcache injection.
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.V(4).Info("Cilium eBPF host routing not detected, skipping ipcache injection")
+		return ctrl.Result{}, nil
+	}
+
+	// Get the Configuration.
+	cfg := &networkingv1beta1.Configuration{}
+	if err := r.Get(ctx, req.NamespacedName, cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("unable to get Configuration: %w", err)
+	}
+
+	// Handle deletion.
+	if !cfg.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, cfg)
+	}
+
+	// Add finalizer if not present.
+	if !controllerutil.ContainsFinalizer(cfg, IPCacheControllerFinalizer) {
+		controllerutil.AddFinalizer(cfg, IPCacheControllerFinalizer)
+		if err := r.Update(ctx, cfg); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Get remote cluster ID.
+	remoteClusterID := cfg.Labels[consts.RemoteClusterID]
+	if remoteClusterID == "" {
+		klog.V(4).Infof("Remote cluster ID not set for Configuration %s", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// Get remote pod CIDR.
+	remotePodCIDR := r.getRemotePodCIDR(cfg)
+	if remotePodCIDR == "" {
+		klog.V(4).Infof("Remote pod CIDR not yet available for Configuration %s", req.NamespacedName)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Get gateway pod IP (tunnel endpoint for this remote cluster).
+	gatewayIP, err := r.getGatewayPodIP(ctx, cfg.Namespace, remoteClusterID)
+	if err != nil {
+		klog.Warningf("Gateway pod IP not available for %s: %v", remoteClusterID, err)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Inject ipcache entry.
+	entry := &RemoteCIDREntry{
+		CIDR:            remotePodCIDR,
+		TunnelEndpoint:  gatewayIP,
+		RemoteClusterID: remoteClusterID,
+		Identity:        2, // Reserved identity for world (cross-cluster traffic).
+	}
+
+	if err := r.injectIPCacheEntry(ctx, entry); err != nil {
+		r.EventsRecorder.Event(cfg, corev1.EventTypeWarning, "IPCacheInjectionFailed",
+			fmt.Sprintf("Failed to inject ipcache entry for %s: %v", remotePodCIDR, err))
+		return ctrl.Result{}, fmt.Errorf("failed to inject ipcache entry: %w", err)
+	}
+
+	klog.Infof("Injected Cilium ipcache entry: %s via gateway %s (cluster: %s)",
+		remotePodCIDR, gatewayIP, remoteClusterID)
+	r.EventsRecorder.Event(cfg, corev1.EventTypeNormal, "IPCacheInjected",
+		fmt.Sprintf("Injected ipcache entry: %s via %s", remotePodCIDR, gatewayIP))
+
+	return ctrl.Result{}, nil
+}
+
+// handleDeletion removes ipcache entries when Configuration is deleted.
+func (r *IPCacheReconciler) handleDeletion(
+	ctx context.Context, cfg *networkingv1beta1.Configuration,
+) (ctrl.Result, error) {
+	klog.V(2).Infof("Handling deletion of Configuration %s/%s", cfg.Namespace, cfg.Name)
+
+	remoteClusterID := cfg.Labels[consts.RemoteClusterID]
+	remotePodCIDR := r.getRemotePodCIDR(cfg)
+
+	if remoteClusterID != "" && remotePodCIDR != "" {
+		if err := r.removeIPCacheEntry(ctx, remotePodCIDR, remoteClusterID); err != nil {
+			klog.Warningf("Failed to remove ipcache entry for %s: %v", remotePodCIDR, err)
+			// Continue with finalizer removal even if ipcache cleanup fails.
+		} else {
+			klog.Infof("Removed Cilium ipcache entry for %s", remotePodCIDR)
+		}
+	}
+
+	// Remove finalizer.
+	controllerutil.RemoveFinalizer(cfg, IPCacheControllerFinalizer)
+	if err := r.Update(ctx, cfg); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// injectIPCacheEntry adds a remote CIDR to Cilium's routing via CiliumNode annotation.
+func (r *IPCacheReconciler) injectIPCacheEntry(ctx context.Context, entry *RemoteCIDREntry) error {
+	// Get the local CiliumNode.
+	ciliumNode, err := r.DynamicClient.Resource(CiliumNodeGVR).Get(ctx, r.LocalNodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get CiliumNode %s: %w", r.LocalNodeName, err)
+	}
+
+	// Prepare annotation.
+	annotations := ciliumNode.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// Create annotation key based on CIDR hash.
+	annotationKey := LiqoRemoteCIDRAnnotationPrefix + hashCIDR(entry.CIDR)
+
+	// Serialize entry to JSON.
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal entry: %w", err)
+	}
+
+	annotations[annotationKey] = string(entryJSON)
+	ciliumNode.SetAnnotations(annotations)
+
+	// Update CiliumNode.
+	_, err = r.DynamicClient.Resource(CiliumNodeGVR).Update(ctx, ciliumNode, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update CiliumNode: %w", err)
+	}
+
+	return nil
+}
+
+// removeIPCacheEntry removes a remote CIDR annotation from CiliumNode.
+func (r *IPCacheReconciler) removeIPCacheEntry(ctx context.Context, cidr, _ string) error {
+	ciliumNode, err := r.DynamicClient.Resource(CiliumNodeGVR).Get(
+		ctx, r.LocalNodeName, metav1.GetOptions{},
+	)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // Node gone, nothing to clean up.
+		}
+		return fmt.Errorf("failed to get CiliumNode: %w", err)
+	}
+
+	annotations := ciliumNode.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+
+	annotationKey := LiqoRemoteCIDRAnnotationPrefix + hashCIDR(cidr)
+	if _, exists := annotations[annotationKey]; !exists {
+		return nil
+	}
+
+	delete(annotations, annotationKey)
+	ciliumNode.SetAnnotations(annotations)
+
+	_, err = r.DynamicClient.Resource(CiliumNodeGVR).Update(ctx, ciliumNode, metav1.UpdateOptions{})
+	return err
+}
+
+// getRemotePodCIDR extracts remote pod CIDR from Configuration.
+func (r *IPCacheReconciler) getRemotePodCIDR(cfg *networkingv1beta1.Configuration) string {
+	if cfg.Status.Remote == nil {
+		return ""
+	}
+	if len(cfg.Status.Remote.CIDR.Pod) == 0 {
+		return ""
+	}
+	return string(cfg.Status.Remote.CIDR.Pod[0])
+}
+
+// getGatewayPodIP finds the gateway pod IP for a remote cluster.
+func (r *IPCacheReconciler) getGatewayPodIP(
+	ctx context.Context, namespace, remoteClusterID string,
+) (string, error) {
+	// List gateway pods for this remote cluster.
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+			consts.RemoteClusterID:      remoteClusterID,
+		},
+	}
+
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return "", fmt.Errorf("failed to list gateway pods: %w", err)
+	}
+
+	// Find running gateway pod.
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			return pod.Status.PodIP, nil
+		}
+	}
+
+	// Fallback: try to get gateway IP from InternalFabric.
+	return r.getGatewayIPFromInternalFabric(ctx, namespace, remoteClusterID)
+}
+
+// getGatewayIPFromInternalFabric gets gateway IP from InternalFabric resource.
+func (r *IPCacheReconciler) getGatewayIPFromInternalFabric(
+	ctx context.Context, namespace, remoteClusterID string,
+) (string, error) {
+	// InternalFabric stores the gateway pod IP.
+	internalFabric := &networkingv1beta1.InternalFabric{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      remoteClusterID,
+	}, internalFabric); err != nil {
+		return "", fmt.Errorf("failed to get InternalFabric: %w", err)
+	}
+
+	if internalFabric.Spec.GatewayIP == "" {
+		return "", fmt.Errorf("gateway IP not set in InternalFabric")
+	}
+
+	return string(internalFabric.Spec.GatewayIP), nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *IPCacheReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.Info("Cilium eBPF host routing not detected, skipping ipcache controller setup")
+		return nil
+	}
+
+	klog.Info("Setting up Cilium ipcache controller for cross-cluster CIDR injection")
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(consts.CtrlInternalFabricFabric + "-cilium-ipcache").
+		For(&networkingv1beta1.Configuration{}).
+		Complete(r)
+}
+
+// hashCIDR creates a short hash of a CIDR for use in annotation keys.
+func hashCIDR(cidr string) string {
+	h := sha256.Sum256([]byte(cidr))
+	return hex.EncodeToString(h[:8])
+}

--- a/pkg/fabric/cilium/ipcache_controller_test.go
+++ b/pkg/fabric/cilium/ipcache_controller_test.go
@@ -1,0 +1,216 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+var _ = Describe("IPCache Controller", func() {
+	var (
+		reconciler *IPCacheReconciler
+		ciliumCfg  *Config
+	)
+
+	BeforeEach(func() {
+		ciliumCfg = &Config{
+			Detected:        true,
+			HostRoutingMode: HostRoutingModeBPF,
+			LRPSupported:    true,
+		}
+	})
+
+	Context("RemoteCIDREntry", func() {
+		Describe("JSON serialization", func() {
+			It("should serialize entry to JSON correctly", func() {
+				entry := &RemoteCIDREntry{
+					CIDR:            remotePodCIDR,
+					TunnelEndpoint:  gatewayIP,
+					RemoteClusterID: remoteClusterID,
+					Identity:        2,
+				}
+				Expect(entry.CIDR).To(Equal(remotePodCIDR))
+				Expect(entry.TunnelEndpoint).To(Equal(gatewayIP))
+				Expect(entry.RemoteClusterID).To(Equal(remoteClusterID))
+				Expect(entry.Identity).To(Equal(uint32(2)))
+			})
+		})
+	})
+
+	Context("hashCIDR", func() {
+		It("should generate consistent hash for same CIDR", func() {
+			hash1 := hashCIDR("10.244.0.0/16")
+			hash2 := hashCIDR("10.244.0.0/16")
+			Expect(hash1).To(Equal(hash2))
+		})
+
+		It("should generate different hashes for different CIDRs", func() {
+			hash1 := hashCIDR("10.244.0.0/16")
+			hash2 := hashCIDR("10.245.0.0/16")
+			Expect(hash1).ToNot(Equal(hash2))
+		})
+
+		It("should generate 16-character hex hash", func() {
+			hash := hashCIDR("10.244.0.0/16")
+			Expect(len(hash)).To(Equal(16))
+		})
+	})
+
+	Context("getRemotePodCIDR", func() {
+		It("should return empty string when Status.Remote is nil", func() {
+			reconciler = &IPCacheReconciler{}
+			cfg := &networkingv1beta1.Configuration{
+				Status: networkingv1beta1.ConfigurationStatus{
+					Remote: nil,
+				},
+			}
+			cidr := reconciler.getRemotePodCIDR(cfg)
+			Expect(cidr).To(BeEmpty())
+		})
+
+		It("should return empty string when Pod CIDR list is empty", func() {
+			reconciler = &IPCacheReconciler{}
+			cfg := &networkingv1beta1.Configuration{
+				Status: networkingv1beta1.ConfigurationStatus{
+					Remote: &networkingv1beta1.ClusterConfig{
+						CIDR: networkingv1beta1.ClusterConfigCIDR{
+							Pod: []networkingv1beta1.CIDR{},
+						},
+					},
+				},
+			}
+			cidr := reconciler.getRemotePodCIDR(cfg)
+			Expect(cidr).To(BeEmpty())
+		})
+
+		It("should return first pod CIDR when available", func() {
+			reconciler = &IPCacheReconciler{}
+			cfg := &networkingv1beta1.Configuration{
+				Status: networkingv1beta1.ConfigurationStatus{
+					Remote: &networkingv1beta1.ClusterConfig{
+						CIDR: networkingv1beta1.ClusterConfigCIDR{
+							Pod: []networkingv1beta1.CIDR{
+								networkingv1beta1.CIDR(remotePodCIDR),
+								networkingv1beta1.CIDR("10.245.0.0/16"),
+							},
+						},
+					},
+				},
+			}
+			cidr := reconciler.getRemotePodCIDR(cfg)
+			Expect(cidr).To(Equal(remotePodCIDR))
+		})
+	})
+
+	Context("Gateway pod discovery", func() {
+		var gatewayPod *corev1.Pod
+
+		BeforeEach(func() {
+			reconciler = &IPCacheReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+				Config: ciliumCfg,
+			}
+
+			gatewayPod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "liqo-gateway-ipcache-" + remoteClusterID,
+					Namespace: "liqo",
+					Labels: map[string]string{
+						gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+						consts.RemoteClusterID:      remoteClusterID,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "gateway",
+							Image: "liqo/gateway:latest",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gatewayPod)).To(Succeed())
+
+			// Status is a subresource - must be updated separately.
+			gatewayPod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: gatewayIP,
+			}
+			Expect(k8sClient.Status().Update(ctx, gatewayPod)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, gatewayPod)
+		})
+
+		Describe("getGatewayPodIP", func() {
+			It("should find gateway pod IP for remote cluster", func() {
+				ip, err := reconciler.getGatewayPodIP(ctx, "liqo", remoteClusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ip).To(Equal(gatewayIP))
+			})
+
+			It("should return error when no gateway pod exists", func() {
+				_, err := reconciler.getGatewayPodIP(ctx, "liqo", "non-existent-cluster")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("Reconciler setup", func() {
+		Describe("SetupWithManager", func() {
+			It("should skip setup when Cilium not detected", func() {
+				r := &IPCacheReconciler{
+					Client: k8sClient,
+					Scheme: scheme.Scheme,
+					Config: nil,
+				}
+				Expect(r.Config).To(BeNil())
+			})
+
+			It("should skip setup when not using BPF host routing", func() {
+				cfg := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeLegacy,
+				}
+				r := &IPCacheReconciler{
+					Client: k8sClient,
+					Scheme: scheme.Scheme,
+					Config: cfg,
+				}
+				Expect(r.Config.IsBPFHostRouting()).To(BeFalse())
+			})
+		})
+	})
+
+	Context("Annotation key generation", func() {
+		It("should generate valid annotation key with prefix", func() {
+			cidr := "10.244.0.0/16"
+			hash := hashCIDR(cidr)
+			annotationKey := LiqoRemoteCIDRAnnotationPrefix + hash
+			Expect(annotationKey).To(HavePrefix(LiqoRemoteCIDRAnnotationPrefix))
+			Expect(len(annotationKey)).To(Equal(len(LiqoRemoteCIDRAnnotationPrefix) + 16))
+		})
+	})
+})

--- a/pkg/fabric/cilium/suite_test.go
+++ b/pkg/fabric/cilium/suite_test.go
@@ -1,0 +1,115 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+const (
+	remoteClusterID = "remote-cluster-id"
+	remotePodCIDR   = "10.244.0.0/16"
+	gatewayIP       = "10.109.0.89"
+)
+
+func TestCilium(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cilium Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	ctx, cancel = context.WithCancel(context.Background())
+	testutil.LogsToGinkgoWriter()
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	Expect(corev1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(networkingv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(liqov1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	// Use a direct (non-cached) client for deterministic test setup/teardown.
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+
+	// Create required namespaces.
+	for _, ns := range []string{"kube-system", "liqo"} {
+		Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		}))).To(Succeed())
+	}
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// createCiliumConfigMap creates a cilium-config ConfigMap with the given data.
+func createCiliumConfigMap(ctx context.Context, cl client.Client, data map[string]string) {
+	deleteCiliumConfigMap(ctx, cl)
+	Expect(cl.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CiliumConfigMapName,
+			Namespace: CiliumNamespace,
+		},
+		Data: data,
+	})).To(Succeed())
+}
+
+// deleteCiliumConfigMap deletes the cilium-config ConfigMap if it exists.
+func deleteCiliumConfigMap(ctx context.Context, cl client.Client) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CiliumConfigMapName,
+			Namespace: CiliumNamespace,
+		},
+	}
+	Expect(client.IgnoreNotFound(cl.Delete(ctx, cm))).To(Succeed())
+}

--- a/pkg/fabric/cilium/vtep_controller.go
+++ b/pkg/fabric/cilium/vtep_controller.go
@@ -1,0 +1,386 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+const (
+	// VTEPControllerFinalizer is the finalizer for VTEP cleanup.
+	VTEPControllerFinalizer = "liqo.io/cilium-vtep-controller"
+	// VTEPControllerName is the controller name.
+	VTEPControllerName = "cilium-vtep-controller"
+
+	// VTEP ConfigMap keys.
+	vtepEnabledKey  = "enable-vtep"
+	vtepEndpointKey = "vtep-endpoint"
+	vtepCIDRKey     = "vtep-cidr"
+	vtepMaskKey     = "vtep-mask"
+	vtepMACKey      = "vtep-mac"
+
+	// LiqoVTEPAnnotation marks Liqo-managed VTEP entries.
+	LiqoVTEPAnnotation = "liqo.io/vtep-managed"
+
+	// defaultGatewayMAC is the fallback MAC address when gateway IP cannot be parsed.
+	defaultGatewayMAC = "82:36:00:00:00:00"
+)
+
+// VTEPEntry represents a VTEP configuration entry for Cilium.
+type VTEPEntry struct {
+	// Endpoint is the gateway pod IP (VTEP device IP).
+	Endpoint string
+	// CIDR is the remote pod CIDR routed via this VTEP.
+	CIDR string
+	// Mask is the netmask for the CIDR.
+	Mask string
+	// MAC is the gateway pod's MAC address.
+	MAC string
+	// RemoteClusterID identifies the remote cluster.
+	RemoteClusterID string
+}
+
+// VTEPReconciler manages Cilium VTEP configuration for Liqo remote CIDRs.
+// When Cilium eBPF host routing is enabled, kernel routing tables are bypassed.
+// This controller configures Cilium's VTEP integration to route remote pod CIDRs
+// through Liqo gateway pods, enabling cross-cluster connectivity.
+type VTEPReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	EventsRecorder record.EventRecorder
+	Config         *Config
+}
+
+// NewVTEPReconciler creates a new VTEPReconciler.
+func NewVTEPReconciler(
+	cl client.Client,
+	scheme *runtime.Scheme,
+	recorder record.EventRecorder,
+	ciliumConfig *Config,
+) *VTEPReconciler {
+	return &VTEPReconciler{
+		Client:         cl,
+		Scheme:         scheme,
+		EventsRecorder: recorder,
+		Config:         ciliumConfig,
+	}
+}
+
+// +kubebuilder:rbac:groups=networking.liqo.io,resources=configurations,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;patch,namespace=kube-system
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile handles Configuration events and manages Cilium VTEP configuration.
+func (r *VTEPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(4).Infof("Reconciling Configuration %s for Cilium VTEP", req.NamespacedName)
+
+	// Skip if Cilium doesn't need VTEP integration.
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.V(4).Info("Cilium eBPF host routing not detected, skipping VTEP configuration")
+		return ctrl.Result{}, nil
+	}
+
+	// Get the Configuration.
+	cfg := &networkingv1beta1.Configuration{}
+	if err := r.Get(ctx, req.NamespacedName, cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Configuration deleted - rebuild VTEP config from remaining Configurations.
+			return r.rebuildVTEPConfig(ctx)
+		}
+		return ctrl.Result{}, fmt.Errorf("unable to get Configuration: %w", err)
+	}
+
+	// Handle deletion.
+	if !cfg.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, cfg)
+	}
+
+	// Add finalizer if not present.
+	if !controllerutil.ContainsFinalizer(cfg, VTEPControllerFinalizer) {
+		controllerutil.AddFinalizer(cfg, VTEPControllerFinalizer)
+		if err := r.Update(ctx, cfg); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Rebuild VTEP configuration with all current Configurations.
+	return r.rebuildVTEPConfig(ctx)
+}
+
+// handleDeletion removes VTEP entries when Configuration is deleted.
+func (r *VTEPReconciler) handleDeletion(
+	ctx context.Context, cfg *networkingv1beta1.Configuration,
+) (ctrl.Result, error) {
+	klog.V(2).Infof("Handling deletion of Configuration %s/%s", cfg.Namespace, cfg.Name)
+
+	// Remove finalizer first.
+	controllerutil.RemoveFinalizer(cfg, VTEPControllerFinalizer)
+	if err := r.Update(ctx, cfg); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+
+	// Rebuild VTEP config without this Configuration.
+	return r.rebuildVTEPConfig(ctx)
+}
+
+// rebuildVTEPConfig collects all VTEP entries from active Configurations
+// and updates the Cilium ConfigMap.
+func (r *VTEPReconciler) rebuildVTEPConfig(ctx context.Context) (ctrl.Result, error) {
+	// List all Configurations.
+	configList := &networkingv1beta1.ConfigurationList{}
+	if err := r.List(ctx, configList); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list Configurations: %w", err)
+	}
+
+	// Collect VTEP entries from each Configuration.
+	var entries []VTEPEntry
+	for i := range configList.Items {
+		cfg := &configList.Items[i]
+		// Skip if being deleted.
+		if !cfg.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		entry, err := r.buildVTEPEntry(ctx, cfg)
+		if err != nil {
+			klog.V(4).Infof("Skipping Configuration %s/%s: %v", cfg.Namespace, cfg.Name, err)
+			continue
+		}
+
+		entries = append(entries, *entry)
+	}
+
+	// Update Cilium ConfigMap.
+	if err := r.updateConfig(ctx, entries); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update Cilium config: %w", err)
+	}
+
+	if len(entries) > 0 {
+		klog.Infof("Updated Cilium VTEP configuration with %d entries", len(entries))
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// buildVTEPEntry creates a VTEPEntry from a Configuration resource.
+func (r *VTEPReconciler) buildVTEPEntry(
+	ctx context.Context, cfg *networkingv1beta1.Configuration,
+) (*VTEPEntry, error) {
+	// Get remote cluster ID.
+	remoteClusterID := cfg.Labels[consts.RemoteClusterID]
+	if remoteClusterID == "" {
+		return nil, fmt.Errorf("remote cluster ID not set")
+	}
+
+	// Get remote pod CIDR.
+	if cfg.Status.Remote == nil || len(cfg.Status.Remote.CIDR.Pod) == 0 {
+		return nil, fmt.Errorf("remote pod CIDR not available")
+	}
+	remotePodCIDR := string(cfg.Status.Remote.CIDR.Pod[0])
+
+	// Get gateway pod IP and MAC.
+	gatewayIP, gatewayMAC, err := r.getGatewayPodInfo(ctx, cfg.Namespace, remoteClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("gateway pod info not available: %w", err)
+	}
+
+	// Calculate netmask from CIDR.
+	_, ipNet, err := net.ParseCIDR(remotePodCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CIDR %s: %w", remotePodCIDR, err)
+	}
+	mask := net.IP(ipNet.Mask).String()
+
+	return &VTEPEntry{
+		Endpoint:        gatewayIP,
+		CIDR:            remotePodCIDR,
+		Mask:            mask,
+		MAC:             gatewayMAC,
+		RemoteClusterID: remoteClusterID,
+	}, nil
+}
+
+// getGatewayPodInfo retrieves the gateway pod's IP and MAC address.
+func (r *VTEPReconciler) getGatewayPodInfo(
+	ctx context.Context, namespace, remoteClusterID string,
+) (ip, mac string, err error) {
+	// List gateway pods for this remote cluster.
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+			consts.RemoteClusterID:      remoteClusterID,
+		},
+	}
+
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return "", "", fmt.Errorf("failed to list gateway pods: %w", err)
+	}
+
+	// Find running gateway pod.
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			// Get MAC address from pod annotations or generate deterministic one.
+			mac := r.getGatewayMAC(pod)
+			return pod.Status.PodIP, mac, nil
+		}
+	}
+
+	// Fallback: try to get gateway IP from InternalFabric.
+	return r.getGatewayIPFromInternalFabric(ctx, namespace, remoteClusterID)
+}
+
+// getGatewayMAC retrieves or generates a MAC address for the gateway pod.
+func (r *VTEPReconciler) getGatewayMAC(pod *corev1.Pod) string {
+	// Check for MAC annotation.
+	if mac, ok := pod.Annotations["liqo.io/gateway-mac"]; ok {
+		return mac
+	}
+
+	// Generate deterministic MAC from pod IP.
+	// Format: 82:36:xx:xx:xx:xx where xx are derived from IP.
+	ip := net.ParseIP(pod.Status.PodIP)
+	if ip == nil {
+		return defaultGatewayMAC
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return defaultGatewayMAC
+	}
+
+	return fmt.Sprintf("82:36:%02x:%02x:%02x:%02x", ip4[0], ip4[1], ip4[2], ip4[3])
+}
+
+// getGatewayIPFromInternalFabric gets gateway IP from InternalFabric resource.
+func (r *VTEPReconciler) getGatewayIPFromInternalFabric(
+	ctx context.Context, namespace, remoteClusterID string,
+) (gatewayIP, gatewayMAC string, err error) {
+	internalFabric := &networkingv1beta1.InternalFabric{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      remoteClusterID,
+	}, internalFabric); err != nil {
+		return "", "", fmt.Errorf("failed to get InternalFabric: %w", err)
+	}
+
+	if internalFabric.Spec.GatewayIP == "" {
+		return "", "", fmt.Errorf("gateway IP not set in InternalFabric")
+	}
+
+	gatewayIP = string(internalFabric.Spec.GatewayIP)
+	// Generate MAC from gateway IP.
+	ip := net.ParseIP(gatewayIP)
+	if ip == nil {
+		return gatewayIP, defaultGatewayMAC, nil
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return gatewayIP, defaultGatewayMAC, nil
+	}
+
+	gatewayMAC = fmt.Sprintf("82:36:%02x:%02x:%02x:%02x", ip4[0], ip4[1], ip4[2], ip4[3])
+	return gatewayIP, gatewayMAC, nil
+}
+
+// updateConfig updates the Cilium ConfigMap with VTEP entries.
+func (r *VTEPReconciler) updateConfig(ctx context.Context, entries []VTEPEntry) error {
+	// Get Cilium ConfigMap.
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: CiliumNamespace,
+		Name:      CiliumConfigMapName,
+	}, cm); err != nil {
+		return fmt.Errorf("failed to get Cilium ConfigMap: %w", err)
+	}
+
+	// Initialize data map if nil.
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+
+	// Build VTEP configuration strings.
+	if len(entries) == 0 {
+		// No entries - disable VTEP.
+		delete(cm.Data, vtepEnabledKey)
+		delete(cm.Data, vtepEndpointKey)
+		delete(cm.Data, vtepCIDRKey)
+		delete(cm.Data, vtepMaskKey)
+		delete(cm.Data, vtepMACKey)
+	} else {
+		// Enable VTEP with entries.
+		var endpoints, cidrs, masks, macs []string
+		for _, entry := range entries {
+			endpoints = append(endpoints, entry.Endpoint)
+			cidrs = append(cidrs, entry.CIDR)
+			masks = append(masks, entry.Mask)
+			macs = append(macs, entry.MAC)
+		}
+
+		cm.Data[vtepEnabledKey] = boolTrue
+		cm.Data[vtepEndpointKey] = strings.Join(endpoints, " ")
+		cm.Data[vtepCIDRKey] = strings.Join(cidrs, " ")
+		cm.Data[vtepMaskKey] = strings.Join(masks, " ")
+		cm.Data[vtepMACKey] = strings.Join(macs, " ")
+	}
+
+	// Update annotation to track Liqo management.
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	cm.Annotations[LiqoVTEPAnnotation] = boolTrue
+
+	// Update ConfigMap.
+	if err := r.Update(ctx, cm); err != nil {
+		return fmt.Errorf("failed to update Cilium ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VTEPReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Config == nil || !r.Config.IsBPFHostRouting() {
+		klog.Info("Cilium eBPF host routing not detected, skipping VTEP controller setup")
+		return nil
+	}
+
+	klog.Info("Setting up Cilium VTEP controller for cross-cluster CIDR routing")
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(consts.CtrlInternalFabricFabric + "-cilium-vtep").
+		For(&networkingv1beta1.Configuration{}).
+		Complete(r)
+}

--- a/pkg/fabric/cilium/vtep_controller_test.go
+++ b/pkg/fabric/cilium/vtep_controller_test.go
@@ -1,0 +1,301 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cilium
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+var _ = Describe("VTEP Controller", func() {
+	var (
+		reconciler *VTEPReconciler
+		ciliumCfg  *Config
+	)
+
+	BeforeEach(func() {
+		ciliumCfg = &Config{
+			Detected:        true,
+			HostRoutingMode: HostRoutingModeBPF,
+		}
+		reconciler = NewVTEPReconciler(
+			k8sClient,
+			scheme.Scheme,
+			nil, // No event recorder needed for tests.
+			ciliumCfg,
+		)
+	})
+
+	Context("VTEPEntry construction", func() {
+		Describe("getGatewayMAC", func() {
+			It("should generate deterministic MAC from pod IP", func() {
+				pod := &corev1.Pod{
+					Status: corev1.PodStatus{
+						PodIP: "10.109.0.89",
+					},
+				}
+				mac := reconciler.getGatewayMAC(pod)
+				Expect(mac).To(Equal("82:36:0a:6d:00:59"))
+			})
+
+			It("should use annotation MAC if present", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"liqo.io/gateway-mac": "aa:bb:cc:dd:ee:ff",
+						},
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.109.0.89",
+					},
+				}
+				mac := reconciler.getGatewayMAC(pod)
+				Expect(mac).To(Equal("aa:bb:cc:dd:ee:ff"))
+			})
+
+			It("should return default MAC for invalid IP", func() {
+				pod := &corev1.Pod{
+					Status: corev1.PodStatus{
+						PodIP: "invalid",
+					},
+				}
+				mac := reconciler.getGatewayMAC(pod)
+				Expect(mac).To(Equal("82:36:00:00:00:00"))
+			})
+		})
+	})
+
+	Context("VTEP ConfigMap updates", func() {
+		AfterEach(func() {
+			deleteCiliumConfigMap(ctx, k8sClient)
+		})
+
+		Describe("updateConfig", func() {
+			BeforeEach(func() {
+				// Create initial cilium-config.
+				createCiliumConfigMap(ctx, k8sClient, map[string]string{
+					"routing-mode": "native",
+				})
+			})
+
+			It("should enable VTEP with single entry", func() {
+				entries := []VTEPEntry{
+					{
+						Endpoint:        "10.109.0.89",
+						CIDR:            "10.244.0.0/16",
+						Mask:            "255.255.0.0",
+						MAC:             "82:36:0a:6d:00:59",
+						RemoteClusterID: remoteClusterID,
+					},
+				}
+
+				err := reconciler.updateConfig(ctx, entries)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify ConfigMap was updated.
+				cm := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      CiliumConfigMapName,
+					Namespace: CiliumNamespace,
+				}, cm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cm.Data["enable-vtep"]).To(Equal("true"))
+				Expect(cm.Data["vtep-endpoint"]).To(Equal("10.109.0.89"))
+				Expect(cm.Data["vtep-cidr"]).To(Equal("10.244.0.0/16"))
+				Expect(cm.Data["vtep-mask"]).To(Equal("255.255.0.0"))
+				Expect(cm.Data["vtep-mac"]).To(Equal("82:36:0a:6d:00:59"))
+				Expect(cm.Annotations[LiqoVTEPAnnotation]).To(Equal("true"))
+			})
+
+			It("should enable VTEP with multiple entries", func() {
+				entries := []VTEPEntry{
+					{
+						Endpoint:        "10.109.0.89",
+						CIDR:            "10.244.0.0/16",
+						Mask:            "255.255.0.0",
+						MAC:             "82:36:0a:6d:00:59",
+						RemoteClusterID: "cluster-1",
+					},
+					{
+						Endpoint:        "10.109.0.90",
+						CIDR:            "10.245.0.0/16",
+						Mask:            "255.255.0.0",
+						MAC:             "82:36:0a:6d:00:5a",
+						RemoteClusterID: "cluster-2",
+					},
+				}
+
+				err := reconciler.updateConfig(ctx, entries)
+				Expect(err).ToNot(HaveOccurred())
+
+				cm := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      CiliumConfigMapName,
+					Namespace: CiliumNamespace,
+				}, cm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cm.Data["vtep-endpoint"]).To(Equal("10.109.0.89 10.109.0.90"))
+				Expect(cm.Data["vtep-cidr"]).To(Equal("10.244.0.0/16 10.245.0.0/16"))
+			})
+
+			It("should disable VTEP when no entries", func() {
+				// First enable VTEP.
+				entries := []VTEPEntry{
+					{
+						Endpoint: "10.109.0.89",
+						CIDR:     "10.244.0.0/16",
+						Mask:     "255.255.0.0",
+						MAC:      "82:36:0a:6d:00:59",
+					},
+				}
+				err := reconciler.updateConfig(ctx, entries)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Then disable by passing empty entries.
+				err = reconciler.updateConfig(ctx, []VTEPEntry{})
+				Expect(err).ToNot(HaveOccurred())
+
+				cm := &corev1.ConfigMap{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      CiliumConfigMapName,
+					Namespace: CiliumNamespace,
+				}, cm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cm.Data).ToNot(HaveKey("enable-vtep"))
+				Expect(cm.Data).ToNot(HaveKey("vtep-endpoint"))
+			})
+		})
+	})
+
+	Context("Gateway pod discovery", func() {
+		var (
+			gatewayPod    *corev1.Pod
+			configuration *networkingv1beta1.Configuration
+		)
+
+		BeforeEach(func() {
+			// Create a gateway pod.
+			gatewayPod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "liqo-gateway-" + remoteClusterID,
+					Namespace: "liqo",
+					Labels: map[string]string{
+						gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
+						consts.RemoteClusterID:      remoteClusterID,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "gateway",
+							Image: "liqo/gateway:latest",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, gatewayPod)).To(Succeed())
+
+			// Status is a subresource - must be updated separately.
+			gatewayPod.Status = corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: gatewayIP,
+			}
+			Expect(k8sClient.Status().Update(ctx, gatewayPod)).To(Succeed())
+
+			// Create a Configuration resource.
+			configuration = &networkingv1beta1.Configuration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "config-" + remoteClusterID,
+					Namespace: "liqo",
+					Labels: map[string]string{
+						consts.RemoteClusterID: remoteClusterID,
+					},
+				},
+				Spec: networkingv1beta1.ConfigurationSpec{},
+			}
+			Expect(k8sClient.Create(ctx, configuration)).To(Succeed())
+
+			// Update Configuration status with remote CIDR.
+			configuration.Status = networkingv1beta1.ConfigurationStatus{
+				Remote: &networkingv1beta1.ClusterConfig{
+					CIDR: networkingv1beta1.ClusterConfigCIDR{
+						Pod: []networkingv1beta1.CIDR{networkingv1beta1.CIDR(remotePodCIDR)},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, configuration)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, gatewayPod)
+			_ = k8sClient.Delete(ctx, configuration)
+		})
+
+		Describe("getGatewayPodInfo", func() {
+			It("should find gateway pod IP and generate MAC", func() {
+				ip, mac, err := reconciler.getGatewayPodInfo(ctx, "liqo", remoteClusterID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ip).To(Equal(gatewayIP))
+				// MAC generated from IP 10.109.0.89 = 82:36:0a:6d:00:59.
+				Expect(mac).To(Equal("82:36:0a:6d:00:59"))
+			})
+		})
+
+		Describe("buildVTEPEntry", func() {
+			It("should build VTEP entry from Configuration", func() {
+				entry, err := reconciler.buildVTEPEntry(ctx, configuration)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entry.Endpoint).To(Equal(gatewayIP))
+				Expect(entry.CIDR).To(Equal(remotePodCIDR))
+				Expect(entry.RemoteClusterID).To(Equal(remoteClusterID))
+
+				// Verify mask calculated correctly from CIDR.
+				_, ipNet, _ := net.ParseCIDR(remotePodCIDR)
+				expectedMask := net.IP(ipNet.Mask).String()
+				Expect(entry.Mask).To(Equal(expectedMask))
+			})
+		})
+	})
+
+	Context("Reconciler setup", func() {
+		Describe("SetupWithManager", func() {
+			It("should skip setup when Cilium not detected", func() {
+				r := NewVTEPReconciler(k8sClient, scheme.Scheme, nil, nil)
+				// This should not error, just skip setup.
+				// We can't easily test SetupWithManager without a full manager.
+				Expect(r.Config).To(BeNil())
+			})
+
+			It("should skip setup when not using BPF host routing", func() {
+				cfg := &Config{
+					Detected:        true,
+					HostRoutingMode: HostRoutingModeLegacy,
+				}
+				r := NewVTEPReconciler(k8sClient, scheme.Scheme, nil, cfg)
+				Expect(r.Config.IsBPFHostRouting()).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/liqoctl/install/rke2/provider.go
+++ b/pkg/liqoctl/install/rke2/provider.go
@@ -1,0 +1,87 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rke2 implements the Liqo install provider for RKE2 clusters.
+package rke2
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/install"
+)
+
+var _ install.Provider = (*Options)(nil)
+
+// Options encapsulates the arguments of the install rke2 command.
+type Options struct {
+	*install.Options
+}
+
+// New initializes a new Provider object.
+func New(o *install.Options) install.Provider {
+	return &Options{Options: o}
+}
+
+// Name returns the name of the provider.
+func (o *Options) Name() string { return "rke2" }
+
+// Examples returns the examples string for the given provider.
+func (o *Options) Examples() string {
+	return `Examples:
+  $ {{ .Executable }} install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+or
+  $ {{ .Executable }} install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-labels region=us-west,environment=production \
+      --pod-cidr 10.0.0.0/16 --service-cidr 10.1.0.0/16 \
+      --reserved-subnets 172.16.0.0/16,192.16.254.0/24
+or (with out-of-band peering for restricted networks)
+  $ {{ .Executable }} install rke2 --api-server-url https://liqo.example.local:9345 \
+      --cluster-id my-rke2-cluster \
+      --cluster-labels region=us-west,environment=production
+`
+}
+
+// RegisterFlags registers the flags for the given provider.
+func (o *Options) RegisterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.APIServer, "api-server-url", "", "The Kubernetes API Server URL (defaults to the one specified in the kubeconfig)")
+	cmd.Flags().StringVar(&o.PodCIDR, "pod-cidr", "10.42.0.0/16", "The Pod CIDR of the cluster")
+	cmd.Flags().StringVar(&o.ServiceCIDR, "service-cidr", "10.43.0.0/16", "The Service CIDR of the cluster")
+}
+
+// Initialize performs the initialization tasks to retrieve the provider-specific parameters.
+func (o *Options) Initialize(_ context.Context) error {
+	// RKE2 API server typically runs on port 9345 and may use localhost addresses.
+	// Disable API server sanity checks to support these scenarios.
+	o.DisableAPIServerSanityChecks = true
+	return nil
+}
+
+// Values returns the customized provider-specifc values file parameters.
+func (o *Options) Values() map[string]interface{} {
+	return map[string]interface{}{
+		"networking": map[string]interface{}{
+			"fabric": map[string]interface{}{
+				"config": map[string]interface{}{
+					// RKE2 uses nftables by default, but monitoring can cause issues
+					// in some environments, similar to K3s
+					"nftablesMonitor": false,
+				},
+			},
+		},
+	}
+}

--- a/pkg/utils/foreigncluster/getters.go
+++ b/pkg/utils/foreigncluster/getters.go
@@ -31,11 +31,33 @@ import (
 )
 
 // GetForeignClusterByID returns a ForeignCluster CR retrieving it by its clusterID.
+//
+// This function implements a three-tier fallback lookup strategy to support both
+// standard label-based peering and out-of-band (manual) peering scenarios:
+//
+//  1. Label-based lookup (O(1) with index): Searches for ForeignClusters with the
+//     liqo.io/remote-cluster-id label matching the clusterID. This is the standard
+//     path used by liqoctl peer and is highly efficient.
+//
+//  2. Name-based lookup (O(1)): Fallback for out-of-band peering where ForeignCluster
+//     resources are created manually (e.g., via GitOps, kubectl apply) with name == clusterID.
+//     Common in RKE2 deployments and restricted network environments.
+//
+//  3. Exhaustive search (O(n)): Final fallback that iterates through ALL ForeignClusters
+//     to find one with spec.ClusterID matching the requested ID. This is expensive and
+//     should rarely be triggered in production.
+//
+// Performance considerations:
+//   - In clusters with many ForeignClusters (>100), the exhaustive search can impact
+//     API server performance. Consider adding liqo.io/remote-cluster-id labels to
+//     manually-created ForeignClusters to avoid this fallback.
+//   - The function logs when fallback #2 or #3 is used to aid in debugging and
+//     identifying misconfigured resources.
 func GetForeignClusterByID(ctx context.Context, cl client.Client, clusterID liqov1beta1.ClusterID) (*liqov1beta1.ForeignCluster, error) {
+	// Fallback #1: Label-based lookup (most efficient, O(1) with index)
 	lSelector := labels.SelectorFromSet(labels.Set{
 		consts.RemoteClusterID: string(clusterID),
 	})
-	// get the foreign cluster by clusterID label
 	foreignClusterList := liqov1beta1.ForeignClusterList{}
 	if err := cl.List(ctx, &foreignClusterList, &client.ListOptions{
 		LabelSelector: lSelector,
@@ -43,7 +65,45 @@ func GetForeignClusterByID(ctx context.Context, cl client.Client, clusterID liqo
 		return nil, err
 	}
 
-	return getForeignCluster(&foreignClusterList, clusterID)
+	// If found by label, return immediately (fast path)
+	if len(foreignClusterList.Items) > 0 {
+		klog.V(4).Infof("Found ForeignCluster %s by label lookup (fast path)", clusterID)
+		return getForeignCluster(&foreignClusterList, clusterID)
+	}
+
+	// Fallback #2: Name-based lookup for out-of-band peering (O(1))
+	// This supports manually-created ForeignCluster resources where name == clusterID
+	klog.V(4).Infof("Label lookup failed for ForeignCluster %s, trying name-based lookup (out-of-band peering)", clusterID)
+	fc := &liqov1beta1.ForeignCluster{}
+	err := cl.Get(ctx, client.ObjectKey{Name: string(clusterID)}, fc)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			// Fallback #3: Exhaustive search through all ForeignClusters (O(n))
+			// WARNING: This is expensive and can impact performance in large clusters
+			klog.Warningf("Name-based lookup failed for ForeignCluster %s, "+
+				"performing exhaustive search across all ForeignClusters (expensive operation)", clusterID)
+			allFCs := &liqov1beta1.ForeignClusterList{}
+			if listErr := cl.List(ctx, allFCs); listErr == nil {
+				for i := range allFCs.Items {
+					if allFCs.Items[i].Spec.ClusterID == clusterID {
+						klog.Warningf("Found ForeignCluster %s via exhaustive search. Consider adding the %s label to this resource for better performance",
+							clusterID, consts.RemoteClusterID)
+						return &allFCs.Items[i], nil
+					}
+				}
+			}
+		}
+		return nil, kerrors.NewNotFound(liqov1beta1.ForeignClusterGroupResource, fmt.Sprintf("foreign cluster with ID %s", clusterID))
+	}
+
+	// Validate that the ForeignCluster found by name has the correct spec.ClusterID
+	if fc.Spec.ClusterID != "" && fc.Spec.ClusterID != clusterID {
+		klog.Warningf("ForeignCluster %s found by name but spec.ClusterID mismatch (expected: %s, got: %s)", fc.Name, clusterID, fc.Spec.ClusterID)
+		return nil, kerrors.NewNotFound(liqov1beta1.ForeignClusterGroupResource, fmt.Sprintf("foreign cluster with ID %s", clusterID))
+	}
+
+	klog.V(4).Infof("Found ForeignCluster %s by name-based lookup (out-of-band peering)", clusterID)
+	return fc, nil
 }
 
 // GetForeignClusterByIDWithDynamicClient returns a ForeignCluster CR retrieving it by its clusterID, using the dynamic interface.
@@ -85,7 +145,7 @@ func GetOlderForeignCluster(
 	var olderTime *metav1.Time
 	for i := range foreignClusterList.Items {
 		fc := &foreignClusterList.Items[i]
-		if olderTime.IsZero() || fc.CreationTimestamp.Before(olderTime) {
+		if olderTime == nil || fc.CreationTimestamp.Before(olderTime) {
 			olderTime = &fc.CreationTimestamp
 			foreignCluster = fc
 		}

--- a/pkg/utils/foreigncluster/getters_suite_test.go
+++ b/pkg/utils/foreigncluster/getters_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foreigncluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestForeignCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ForeignCluster Utils Suite")
+}

--- a/pkg/utils/foreigncluster/getters_test.go
+++ b/pkg/utils/foreigncluster/getters_test.go
@@ -1,0 +1,280 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foreigncluster_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/foreigncluster"
+)
+
+var _ = Describe("GetForeignClusterByID function", func() {
+	const (
+		testClusterID1 = liqov1beta1.ClusterID("test-cluster-1")
+		testClusterID2 = liqov1beta1.ClusterID("test-cluster-2")
+		testClusterID3 = liqov1beta1.ClusterID("test-cluster-3")
+		testClusterID4 = liqov1beta1.ClusterID("test-cluster-4")
+		nonExistentID  = liqov1beta1.ClusterID("non-existent-cluster")
+	)
+
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+		cl     client.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(liqov1beta1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Context("Fallback #1: Label-based lookup (fast path)", func() {
+		BeforeEach(func() {
+			// Create a ForeignCluster with the standard label
+			fc := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-with-label",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc).Build()
+		})
+
+		It("should find ForeignCluster by label", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Spec.ClusterID).To(Equal(testClusterID1))
+			Expect(fc.Name).To(Equal("fc-with-label"))
+		})
+
+		It("should return not found for non-existent cluster", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, nonExistentID)
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(fc).To(BeNil())
+		})
+	})
+
+	Context("Fallback #2: Name-based lookup (out-of-band peering)", func() {
+		BeforeEach(func() {
+			// Create a ForeignCluster without the label, but with name == clusterID
+			// This simulates manual/out-of-band creation
+			fc := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID2), // Name matches clusterID
+					// Note: No liqo.io/remote-cluster-id label
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID2,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc).Build()
+		})
+
+		It("should find ForeignCluster by name when label is missing", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Spec.ClusterID).To(Equal(testClusterID2))
+			Expect(fc.Name).To(Equal(string(testClusterID2)))
+		})
+
+		It("should validate spec.ClusterID matches requested ID", func() {
+			// Create a ForeignCluster where name matches but spec.ClusterID doesn't
+			fcMismatch := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID3),
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "different-cluster-id", // Mismatch!
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fcMismatch).Build()
+
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID3)
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(fc).To(BeNil())
+		})
+	})
+
+	Context("Fallback #3: Exhaustive search (expensive operation)", func() {
+		BeforeEach(func() {
+			// Create multiple ForeignClusters, none with the correct label or name
+			// Only one has the matching spec.ClusterID
+			fc1 := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "random-name-1",
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "some-other-cluster",
+				},
+			}
+			fc2 := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "random-name-2",
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID4, // This is the one we're looking for
+				},
+			}
+			fc3 := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "random-name-3",
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "yet-another-cluster",
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc1, fc2, fc3).Build()
+		})
+
+		It("should find ForeignCluster via exhaustive search when label and name lookups fail", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Spec.ClusterID).To(Equal(testClusterID4))
+			Expect(fc.Name).To(Equal("random-name-2"))
+		})
+
+		It("should return not found when exhaustive search finds nothing", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, nonExistentID)
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			Expect(fc).To(BeNil())
+		})
+	})
+
+	Context("Multiple ForeignClusters with same label", func() {
+		var (
+			fc1 *liqov1beta1.ForeignCluster
+			fc2 *liqov1beta1.ForeignCluster
+		)
+
+		BeforeEach(func() {
+			// Create two ForeignClusters with the same label
+			// The function should return the older one based on creationTimestamp
+			fc1 = &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-older",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+					CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-24 * time.Hour)}, // 1 day ago
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			fc2 = &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-newer",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+					CreationTimestamp: metav1.Now(), // Now
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fc1, fc2).Build()
+		})
+
+		It("should return the older ForeignCluster when multiple exist", func() {
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Name).To(Equal("fc-older"))
+		})
+	})
+
+	Context("Edge cases", func() {
+		It("should handle empty clusterID gracefully", func() {
+			cl = fake.NewClientBuilder().WithScheme(scheme).Build()
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, "")
+			Expect(err).To(HaveOccurred())
+			Expect(fc).To(BeNil())
+		})
+
+		It("should handle ForeignCluster with empty spec.ClusterID in name-based lookup", func() {
+			// ForeignCluster with name matching but empty spec.ClusterID should still be found
+			fcEmpty := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID2),
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: "", // Empty
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fcEmpty).Build()
+
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			Expect(fc.Name).To(Equal(string(testClusterID2)))
+		})
+	})
+
+	Context("Combination scenarios (testing fallback chain)", func() {
+		It("should prefer label-based lookup over name-based when both exist", func() {
+			// Create two ForeignClusters: one with label, one matching by name
+			fcWithLabel := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fc-with-label",
+					Labels: map[string]string{
+						consts.RemoteClusterID: string(testClusterID1),
+					},
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			fcByName := &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(testClusterID1), // Name matches
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: testClusterID1,
+				},
+			}
+			cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(fcWithLabel, fcByName).Build()
+
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, testClusterID1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fc).ToNot(BeNil())
+			// Should return the one found by label (fast path)
+			Expect(fc.Name).To(Equal("fc-with-label"))
+		})
+	})
+})


### PR DESCRIPTION
## Purpose

Combined regression test branch with both changesets merged to verify no conflicts or interactions between:

- **Cilium eBPF host routing** (#4) — `pkg/fabric/cilium/` + `cmd/fabric/main.go`
- **RKE2 install provider** (#5) — `pkg/liqoctl/install/rke2/` + `pkg/utils/foreigncluster/`

## Recent Changes (2026-02-24)

### Bug Fix: Cilium ConfigMap Key Name
The detection code checked `bpf-host-legacy-routing` (Helm value naming convention) instead of `enable-host-legacy-routing` (actual Cilium ConfigMap key). This caused `LegacyHostRoutingEnabled` to always report false even when Cilium has legacy routing enabled.

### Fix: Missing RBAC Template
The `liqo-fabric-Role.yaml` file existed in `deployments/liqo/files/` but was never referenced by any Helm template. Added Role + RoleBinding resources to `liqo-fabric-rbac.yaml` so the fabric SA can read `cilium-config` in kube-system.

### CI: Focused Fabric Build Workflow
Added `.github/workflows/build-fabric.yml` that builds and pushes fabric images to `ghcr.io/jesssullivan/fabric-ci` on feature branch pushes. Uses `branch-shortsha` tag format.

## Tested On

**Civo K3s** (Cilium CNI, tunnel: vxlan, enable-host-legacy-routing: true):

| Before RBAC Fix | After RBAC Fix |
|-----------------|----------------|
| `Failed to detect Cilium: configmaps forbidden` | `Cilium detected: HostRouting=Legacy` |

Cross-cluster mail delivery (postfix on honey → dovecot on Civo via Liqo tunnel): ✅

## Architecture Notes

The fork's VTEP/ipcache controllers solve **routing** (when eBPF bypasses kernel route tables). The CiliumNetworkPolicy fix for Liqo gateway identities solves **policy** (identity-based denials). These are orthogonal.

## Do not merge

This PR exists for CI validation and development staging.